### PR TITLE
Add Windows install helper and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 
 - [Experimental technology disclaimer](#experimental-technology-disclaimer)
 - [Quickstart](#quickstart)
+  - [Windows setup](#windows-setup)
 - [Why Codex?](#why-codex)
 - [Security model & permissions](#security-model--permissions)
   - [Platform sandboxing details](#platform-sandboxing-details)
@@ -143,6 +144,13 @@ That's it - Codex will scaffold a file, run it inside a sandbox, install any
 missing dependencies, and show you the live result. Approve the changes and
 they'll be committed to your working directory.
 
+### Windows setup
+
+Windows users can run [`scripts/install_windows.ps1`](./scripts/install_windows.ps1) from PowerShell.
+The script updates your `PATH`, writes a default bilingual `~/.codex/AGENTS.md`,
+and optionally installs voice support. It also lets you pick the default model
+provider, fetching Gemini model names if that provider is selected.
+
 ---
 
 ## Why Codex?
@@ -204,7 +212,7 @@ The hardening mechanism Codex uses depends on your OS:
 
 | Requirement                 | Details                                                         |
 | --------------------------- | --------------------------------------------------------------- |
-| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 **via WSL2** |
+| Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 (WSL2 recommended) |
 | Node.js                     | **22 or newer** (LTS recommended)                               |
 | Git (optional, recommended) | 2.23+ for built-in PR helpers                                   |
 | RAM                         | 4-GB minimum (8-GB recommended)                                 |
@@ -459,6 +467,9 @@ You can create a `~/.codex/AGENTS.md` file to define custom guidance for the age
 - Only use git commands when explicitly requested
 ```
 
+The `scripts/AGENTS_WINDOWS_TEMPLATE.md` file contains a bilingual example suitable
+for Windows installations.
+
 ### Environment variables setup
 
 For each AI provider, you need to set the corresponding API key in your environment variables. For example:
@@ -510,7 +521,7 @@ Codex runs model-generated commands in a sandbox. If a proposed command or file 
 <details>
 <summary>Does it work on Windows?</summary>
 
-Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) - Codex has been tested on macOS and Linux with Node 22.
+Yes. A PowerShell helper is provided at `scripts/install_windows.ps1` for a basic native setup. Running it will configure the `PATH`, create a default `~/.codex` folder with bilingual instructions, and optionally enable audio features. Using [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) is still recommended for sandboxing, but the script works on Windows 11 without WSL.
 
 </details>
 

--- a/scripts/AGENTS_WINDOWS_TEMPLATE.md
+++ b/scripts/AGENTS_WINDOWS_TEMPLATE.md
@@ -1,0 +1,10 @@
+# Windows instructions (English)
+- Explain any action that requires administrator privileges and why before executing.
+- Use the ask-user tool to confirm such actions.
+- Respond in English when the user's request is in English.
+
+---
+
+# Instructions Windows (Français)
+- Avant d'exécuter une action nécessitant des droits administrateur, explique pourquoi et demande confirmation avec l'outil ask-user.
+- Réponds en français si la demande est formulée en français.

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1,0 +1,93 @@
+# PowerShell script to configure Codex on Windows
+param(
+    [switch]$Audio
+)
+
+Write-Host "Codex CLI Windows setup" -ForegroundColor Cyan
+
+# Verify Node.js presence
+$node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $node) {
+    Write-Host "Node.js 22+ is required. Please install it from https://nodejs.org and re-run this script." -ForegroundColor Red
+    exit 1
+}
+$nodeDir = Split-Path $node.Source
+if ($env:PATH -notlike "*$nodeDir*") {
+    Write-Host "Adding Node.js directory to PATH" -ForegroundColor Yellow
+    [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$nodeDir", "User")
+}
+
+# Ensure ~/.codex exists
+$codexDir = Join-Path $env:USERPROFILE ".codex"
+if (!(Test-Path $codexDir)) {
+    New-Item -ItemType Directory -Path $codexDir | Out-Null
+}
+
+# Optional audio setup
+$installAudio = $Audio
+if (-not $Audio) {
+    $resp = Read-Host "Install optional audio packages (pyttsx3 & speech_recognition)? [y/N]"
+    if ($resp -match '^[Yy]') { $installAudio = $true }
+}
+if ($installAudio) {
+    try {
+        pip install --user pyttsx3 SpeechRecognition | Out-Null
+        Write-Host "Audio packages installed" -ForegroundColor Green
+    } catch {
+        Write-Host "Failed to install audio packages: $_" -ForegroundColor Red
+    }
+}
+
+# Choose provider
+$providers = @("OpenAI","Claude","Gemini")
+Write-Host "Select default provider:" -ForegroundColor Cyan
+for ($i=0; $i -lt $providers.Count; $i++) { Write-Host "  [$($i+1)] $($providers[$i])" }
+$choice = Read-Host "Enter choice (1-3)"; if (-not $choice) { $choice = '1' }
+$provider = $providers[[int]$choice - 1]
+$config = @{ provider = $provider }
+
+switch ($provider) {
+    'OpenAI' { $config.model = 'gpt-4o' }
+    'Claude' { $config.model = 'claude-3-opus-20240229' }
+    'Gemini' {
+        $token = Read-Host "Gemini API key"
+        [Environment]::SetEnvironmentVariable('GEMINI_API_KEY',$token,'User')
+        $models = @("models/gemini-1.5-pro-latest")
+        try {
+            $resp = Invoke-RestMethod "https://generativelanguage.googleapis.com/v1/models?key=$token"
+            if ($resp.models) { $models = $resp.models | ForEach-Object { $_.name } }
+        } catch { Write-Host "Could not fetch Gemini models: $_" -ForegroundColor Yellow }
+        for ($i=0; $i -lt $models.Count; $i++) { Write-Host "  [$($i+1)] $($models[$i])" }
+        $mChoice = Read-Host "Select Gemini model"; if (-not $mChoice) { $mChoice = '1' }
+        $config.model = $models[[int]$mChoice - 1]
+        $config.providers = @{ gemini = @{ name='Gemini'; baseURL='https://generativelanguage.googleapis.com/v1beta/openai'; envKey='GEMINI_API_KEY' } }
+    }
+}
+
+$configPath = Join-Path $codexDir "config.json"
+$config | ConvertTo-Json -Depth 3 | Out-File $configPath -Encoding UTF8
+Write-Host "Wrote configuration to $configPath" -ForegroundColor Green
+
+# Create default AGENTS.md with bilingual instructions
+$agentsPath = Join-Path $codexDir "AGENTS.md"
+@'
+# Windows instructions (English)
+- Explain any command requiring administrator rights and ask for confirmation using the ask-user tool.
+- Reply in English when the prompt is in English.
+
+---
+
+# Instructions Windows (Français)
+- Explique chaque commande nécessitant des privilèges administrateur et demande une confirmation avec l'outil ask-user.
+- Réponds en français lorsque la demande est en français.
+'@ | Out-File $agentsPath -Encoding UTF8
+Write-Host "Wrote default instructions to $agentsPath" -ForegroundColor Green
+
+# Ensure npm global bin is in PATH
+$npmBin = (npm bin -g).Trim()
+if ($env:PATH -notlike "*$npmBin*") {
+    Write-Host "Adding npm global bin to PATH" -ForegroundColor Yellow
+    [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$npmBin", "User")
+}
+
+Write-Host "Installation complete. Restart your terminal for PATH changes to take effect." -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- add a PowerShell `install_windows.ps1` script for setting up Codex on native Windows
- provide example bilingual instructions `AGENTS_WINDOWS_TEMPLATE.md`
- document Windows setup and update system requirements

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4caf4eb08329b20d1bfb4f76371e