### PR TITLE
Fix Windows setup path and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,13 @@ they'll be committed to your working directory.
 
 ### Windows setup
 
-Windows users can run [`scripts/install_windows.ps1`](./scripts/install_windows.ps1) from PowerShell.
-The script updates your `PATH`, writes a default bilingual `~/.codex/AGENTS.md`,
-and optionally installs voice support. It also lets you pick the default model
-provider, fetching Gemini model names if that provider is selected.
+Windows users should run [`scripts/install_windows.ps1`](./scripts/install_windows.ps1) from PowerShell.
+This helper verifies Node is available, updates your `PATH`, writes a default
+`~/.codex/AGENTS.md`, and can install the CLI itself using the customized
+Windows build. It optionally installs voice packages and lets you select the
+default model provider, fetching Gemini model names when needed. A minimal
+Python helper for interactive prompts is provided at
+[`scripts/windows_agent.py`](./scripts/windows_agent.py).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "pnpm --filter @openai/codex run lint:fix",
     "typecheck": "pnpm --filter @openai/codex run typecheck",
     "changelog": "git-cliff --config cliff.toml --output CHANGELOG.ignore.md $LAST_RELEASE_TAG..HEAD",
-    "prepare": "husky",
+    "prepare": "node -e \"try{require('husky').install()}catch(e){}\"",
     "husky:add": "husky add"
   },
   "devDependencies": {

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -90,4 +90,15 @@ if ($env:PATH -notlike "*$npmBin*") {
     [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$npmBin", "User")
 }
 
+# Optional CLI installation
+$respCli = Read-Host "Install Codex CLI now? [Y/n]"
+if ($respCli -match '^[Yy]' -or $respCli -eq '') {
+    try {
+        npm install -g github:damdam775/codex#codex_windows_version
+        Write-Host "Codex CLI installed" -ForegroundColor Green
+    } catch {
+        Write-Host "Failed to install Codex CLI: $_" -ForegroundColor Red
+    }
+}
+
 Write-Host "Installation complete. Restart your terminal for PATH changes to take effect." -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- skip husky if it's missing to avoid install errors
- update PowerShell install script to optionally install the CLI
- document the helper script and new install behaviour

## Testing
- `pnpm install`
- `pnpm test` *(fails: Process with PID failed to terminate within 500ms)*
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b55ed22988329af2c16f40b518a90