### PR TITLE
Fix Windows install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center">Lightweight coding agent that runs in your terminal</p>
 <p align="center"><strong>Windows optimized version</strong></p>
 
-<p align="center"><code>npm i -g https://github.com/damdam775/codex/codex-cli.git#codex_windows_version</code></p>
+<p align="center"><code>git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git && npm install -g ./codex/codex-cli</code></p>
 
 ![Codex demo GIF using: codex "explain this codebase to me"](./.github/demo.gif)
 
@@ -78,7 +78,8 @@ This branch is optimized for Windows.
 Install this customized Windows build from GitHub:
 
 ```shell
-npm install -g https://github.com/damdam775/codex/codex-cli.git#codex_windows_version
+git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+npm install -g ./codex/codex-cli
 ```
 
 Next, set your OpenAI API key as an environment variable:
@@ -259,7 +260,8 @@ Run Codex head-less in pipelines. Example GitHub Action step:
 ```yaml
 - name: Update changelog via Codex
   run: |
-    npm install -g https://github.com/damdam775/codex/codex-cli.git#codex_windows_version
+    git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+    npm install -g ./codex/codex-cli
     export OPENAI_API_KEY="${{ secrets.OPENAI_KEY }}"
     codex -a auto-edit --quiet "update CHANGELOG for next release"
 ```
@@ -299,7 +301,8 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 
 ```bash
 # Customized Windows build
-npm install -g https://github.com/damdam775/codex/codex-cli.git#codex_windows_version
+git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+npm install -g ./codex/codex-cli
 # Official npm package
 # npm install -g @openai/codex
 # or
@@ -545,7 +548,10 @@ OpenAI rejected the request. Error details: Status: 400, Code: unsupported_param
 ```
 
 You may need to upgrade to a more recent build with:
-`npm i -g https://github.com/damdam775/codex/codex-cli.git#codex_windows_version`
+```bash
+git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+npm install -g ./codex/codex-cli
+```
 
 ---
 

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -98,7 +98,11 @@ if ($respCli -match '^[Yy]' -or $respCli -eq '') {
     try {
         # Force git to use HTTPS for GitHub in case SSH keys are not configured
         git config --global url."https://github.com/".insteadOf "git@github.com:" | Out-Null
-        npm install -g https://github.com/damdam775/codex/codex-cli.git#codex_windows_version
+        $tmp = Join-Path $env:TEMP "codex-cli-install"
+        if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
+        git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git $tmp | Out-Null
+        npm install -g (Join-Path $tmp "codex-cli")
+        Remove-Item $tmp -Recurse -Force
         $codexCmd = Get-Command codex -ErrorAction SilentlyContinue
         if (-not $codexCmd) {
             Write-Host "CLI installed but 'codex' not found in PATH. Restart your terminal or check npm prefix." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- fix Windows install script to clone repo before running `npm install`
- update README to show the new installation method

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test` *(fails: rawExec process group termination)*

------
https://chatgpt.com/codex/tasks/task_e_685ba3861c2c8329b3b2f3e27b36da3b