### PR TITLE
feat(cli): support windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <p align="center">Lightweight coding agent that runs in your terminal</p>
 <p align="center"><strong>Windows optimized version</strong></p>
 
-<p align="center"><code>git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git</code></p>
+<p align="center"><code>git clone --depth 1 https://github.com/openai/codex.git</code></p>
 <p align="center"><code>cd codex/codex-cli && npm install && npm run build && npm install -g .</code></p>
 
 ![Codex demo GIF using: codex "explain this codebase to me"](./.github/demo.gif)
@@ -76,10 +76,10 @@ Help us improve by filing issues or submitting PRs (see the section below for ho
 
 This branch is optimized for Windows.
 
-Install this customized Windows build from GitHub:
+Install this Windows build from GitHub:
 
 ```shell
-git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+git clone --depth 1 https://github.com/openai/codex.git
 npm install -g ./codex/codex-cli
 ```
 
@@ -265,7 +265,7 @@ Run Codex head-less in pipelines. Example GitHub Action step:
 ```yaml
 - name: Update changelog via Codex
   run: |
-    git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+    git clone --depth 1 https://github.com/openai/codex.git
     npm install -g ./codex/codex-cli
     export OPENAI_API_KEY="${{ secrets.OPENAI_KEY }}"
     codex -a auto-edit --quiet "update CHANGELOG for next release"
@@ -306,7 +306,7 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 
 ```bash
 # Customized Windows build
-git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+git clone --depth 1 https://github.com/openai/codex.git
 npm install -g ./codex/codex-cli
 # Official npm package
 # npm install -g @openai/codex
@@ -554,7 +554,7 @@ OpenAI rejected the request. Error details: Status: 400, Code: unsupported_param
 
 You may need to upgrade to a more recent build with:
 ```bash
-git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git
+git clone --depth 1 https://github.com/openai/codex.git
 npm install -g ./codex/codex-cli
 ```
 

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -64,6 +64,18 @@ if (wantsNative) {
           break;
       }
       break;
+    case "win32":
+      switch (arch) {
+        case "x64":
+          targetTriple = "x86_64-pc-windows-msvc";
+          break;
+        case "arm64":
+          targetTriple = "aarch64-pc-windows-msvc";
+          break;
+        default:
+          break;
+      }
+      break;
     default:
       break;
   }
@@ -71,8 +83,12 @@ if (wantsNative) {
   if (!targetTriple) {
     throw new Error(`Unsupported platform: ${platform} (${arch})`);
   }
-
-  const binaryPath = path.join(__dirname, "..", "bin", `codex-${targetTriple}`);
+  const binaryPath = path.join(
+    __dirname,
+    "..",
+    "bin",
+    `codex-${targetTriple}${platform === "win32" ? ".exe" : ""}`,
+  );
   const result = spawnSync(binaryPath, process.argv.slice(2), {
     stdio: "inherit",
   });

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -100,7 +100,7 @@ if ($respCli -match '^[Yy]' -or $respCli -eq '') {
         git config --global url."https://github.com/".insteadOf "git@github.com:" | Out-Null
         $tmp = Join-Path $env:TEMP "codex-cli-install"
         if (Test-Path $tmp) { Remove-Item $tmp -Recurse -Force }
-        git clone --depth 1 --branch codex_windows_version https://github.com/damdam775/codex.git $tmp | Out-Null
+        git clone --depth 1 https://github.com/openai/codex.git $tmp | Out-Null
         npm install -g (Join-Path $tmp "codex-cli")
         Remove-Item $tmp -Recurse -Force
         $codexCmd = Get-Command codex -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- allow native CLI execution on Windows by detecting win32 targets and using `.exe`
- update Windows install script to clone official repository
- refresh README Windows setup instructions

## Testing
- `pnpm --filter ./codex-cli lint`
- `pnpm --filter ./codex-cli test` *(fails: Process with PID #### failed to terminate)*

------
https://chatgpt.com/codex/tasks/task_e_68939e8d99a88329b3d34b0d667b283d