### PR TITLE
feat: improve windows support and sandbox controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,14 +153,17 @@ they'll be committed to your working directory.
 
 ### Windows setup
 
-Windows users should run [`scripts/install_windows.ps1`](./scripts/install_windows.ps1) from PowerShell.
-Make sure you have **Node.js 22 or newer** installed first. The script verifies
-the version, updates your `PATH`, writes a default `~/.codex/AGENTS.md`, and can
-install the CLI itself using the customized Windows build. It optionally
-installs voice packages and lets you select the default model provider,
-fetching Gemini model names when needed. A minimal Python helper for
-interactive prompts is provided at [`scripts/windows_agent.py`](./scripts/windows_agent.py).
-**Note:** The script adds Node and npm's global bin folder to your PATH. If running `codex` opens the JavaScript file in an editor, reinstall Node.js or run the setup script again to fix file associations.
+Windows users should run [`install_windows.bat`](./install_windows.bat), which
+invokes the PowerShell installer (`scripts/install_windows.ps1`). Make sure you
+have **Node.js 22 or newer** installed first. The script verifies the version,
+updates your `PATH`, writes a default `~/.codex/AGENTS.md`, and can install the
+CLI itself using the customized Windows build. It optionally installs voice
+packages and lets you select the default model provider, fetching Gemini model
+names when needed. A minimal Python helper for interactive prompts is provided
+at [`scripts/windows_agent.py`](./scripts/windows_agent.py). **Note:** The
+script adds Node and npm's global bin folder to your PATH. If running `codex`
+opens the JavaScript file in an editor, reinstall Node.js or run the setup
+script again to fix file associations.
 
 
 ---

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -104,9 +104,10 @@ const cli = meow(
     --reasoning <effort>      Set the reasoning effort level (low, medium, high) (default: high)
 
   Dangerous options
-    --dangerously-auto-approve-everything
+      --dangerously-auto-approve-everything
                                Skip all confirmation prompts and execute commands without
                                sandboxing. Intended solely for ephemeral local testing.
+      --no-sandbox              Run commands without sandboxing (use with caution).
 
   Experimental options
     -f, --full-context         Launch in "full-context" mode which loads the entire repository
@@ -146,6 +147,10 @@ const cli = meow(
         type: "boolean",
         description:
           "Automatically approve all commands without prompting. This is EXTREMELY DANGEROUS and should only be used in trusted environments.",
+      },
+      noSandbox: {
+        type: "boolean",
+        description: "Run commands without sandboxing",
       },
       autoEdit: {
         type: "boolean",
@@ -285,6 +290,10 @@ let config = loadConfig(undefined, undefined, {
   projectDocPath: cli.flags.projectDoc,
   isFullContext: fullContextMode,
 });
+
+if (cli.flags.noSandbox) {
+  config.allowNoSandbox = true;
+}
 
 // `prompt` can be updated later when the user resumes a previous session
 // via the `--history` flag. Therefore it must be declared with `let` rather

--- a/codex-cli/src/components/vendor/ink-text-input.tsx
+++ b/codex-cli/src/components/vendor/ink-text-input.tsx
@@ -269,11 +269,14 @@ function TextInput({
             originalValue.slice(cursorOffset, originalValue.length);
           nextCursorOffset++;
         } else {
-          // Handle Enter key: support bash-style line continuation with backslash
-          // -- count consecutive backslashes immediately before cursor
-          // -- only a single trailing backslash at end indicates line continuation
+          // Handle Enter key: support line continuation. Use backslash on
+          // Unix-like systems and caret (^) on Windows.
+          // -- count consecutive continuation characters immediately before cursor
+          // -- only a single trailing continuation char at end indicates continuation
           const isAtEnd = cursorOffset === originalValue.length;
-          const trailingMatch = originalValue.match(/\\+$/);
+          const continuationRegex =
+            process.platform === "win32" ? /\^+$/ : /\\+$/;
+          const trailingMatch = originalValue.match(continuationRegex);
           const trailingCount = trailingMatch ? trailingMatch[0].length : 0;
           if (isAtEnd && trailingCount === 1) {
             nextValue += "\n";

--- a/codex-cli/src/utils/agent/platform-commands.ts
+++ b/codex-cli/src/utils/agent/platform-commands.ts
@@ -4,6 +4,11 @@
 
 import { log } from "../logger/log.js";
 
+// On Windows, many useful commands are implemented as shell built-ins rather
+// than standalone executables. `COMSPEC` points to the command interpreter
+// (typically `cmd.exe`) which we use when invoking such built-ins.
+const COMSPEC = process.env["COMSPEC"] || "cmd";
+
 /**
  * Map of Unix commands to their Windows equivalents
  */
@@ -53,6 +58,16 @@ export function adaptCommandForPlatform(command: Array<string>): Array<string> {
   }
 
   const cmd = command[0];
+
+  // Special cases for commands that are Windows shell built-ins.
+  if (cmd === "pwd") {
+    log("Adapting command 'pwd' for Windows platform");
+    return [COMSPEC, "/c", "cd"];
+  }
+  if (cmd === "env" || cmd === "printenv") {
+    log(`Adapting command '${cmd}' for Windows platform`);
+    return [COMSPEC, "/c", "set"];
+  }
 
   // If cmd is undefined or the command doesn't need adaptation, return it as is
   if (!cmd || !COMMAND_MAP[cmd]) {

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -170,6 +170,7 @@ export type StoredConfig = {
    * terminal output.
    */
   fileOpener?: FileOpenerScheme;
+  allowNoSandbox?: boolean;
 };
 
 // Minimal config written on first run.  An *empty* model string ensures that
@@ -215,6 +216,8 @@ export type AppConfig = {
     };
   };
   fileOpener?: FileOpenerScheme;
+  /** Allow running commands without sandboxing */
+  allowNoSandbox?: boolean;
 };
 
 // Formatting (quiet mode-only).
@@ -439,6 +442,8 @@ export const loadConfig = (
     disableResponseStorage: storedConfig.disableResponseStorage === true,
     reasoningEffort: storedConfig.reasoningEffort,
     fileOpener: storedConfig.fileOpener,
+    allowNoSandbox:
+      storedConfig.allowNoSandbox ?? CODEX_UNSAFE_ALLOW_NO_SANDBOX,
   };
 
   // -----------------------------------------------------------------------
@@ -560,6 +565,7 @@ export const saveConfig = (
     disableResponseStorage: config.disableResponseStorage,
     flexMode: config.flexMode,
     reasoningEffort: config.reasoningEffort,
+    allowNoSandbox: config.allowNoSandbox,
   };
 
   // Add history settings if they exist


### PR DESCRIPTION
## Summary
- add caret-based line continuation on Windows
- adapt Unix commands to Windows built-ins and add `--no-sandbox` flag
- document Windows installation via `install_windows.bat`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Process with PID 6555 failed to terminate within 500ms)*

------
https://chatgpt.com/codex/tasks/task_e_689558b4ba608329a9a66ce9440465b0