### PR TITLE
feat: enforce Windows command usage with validator

### DIFF
--- a/codex-cli/scripts/command_validator.py
+++ b/codex-cli/scripts/command_validator.py
@@ -1,0 +1,57 @@
+import json
+import os
+import platform
+import sys
+
+COMMAND_MAP = {
+    "ls": "dir",
+    "grep": "findstr",
+    "cat": "type",
+    "rm": "del",
+    "cp": "copy",
+    "mv": "move",
+    "touch": "echo.>",
+    "mkdir": "md",
+}
+
+OPTION_MAP = {
+    "ls": {
+        "-l": "/p",
+        "-a": "/a",
+        "-R": "/s",
+    },
+    "grep": {
+        "-i": "/i",
+        "-r": "/s",
+    },
+}
+
+def adapt(cmd):
+    if not cmd:
+        return cmd, ""
+    base = cmd[0]
+    if base == "pwd":
+        return ["cmd", "/c", "cd"], "Converted 'pwd' to 'cd' for Windows CMD."
+    if base in ("env", "printenv"):
+        return ["cmd", "/c", "set"], f"Converted '{base}' to 'set' for Windows CMD."
+    if base not in COMMAND_MAP:
+        return cmd, ""
+    new_cmd = [COMMAND_MAP[base], *cmd[1:]]
+    opts = OPTION_MAP.get(base, {})
+    for i in range(1, len(new_cmd)):
+        new_cmd[i] = opts.get(new_cmd[i], new_cmd[i])
+    return new_cmd, f"Converted '{base}' to '{new_cmd[0]}' for Windows CMD."
+
+def main():
+    original = json.loads(sys.argv[1])
+    if platform.system().lower() != "windows":
+        print(json.dumps({"command": original}))
+        return
+    adapted, msg = adapt(list(original))
+    shell = "CMD" if os.getenv("PROMPT") is not None else "PowerShell"
+    if msg:
+        msg = f"{msg} Please provide only commands compatible with Windows {shell}."
+    print(json.dumps({"command": adapted, "message": msg}))
+
+if __name__ == "__main__":
+    main()

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1610,6 +1610,13 @@ if (spawnSync("rg", ["--version"], { stdio: "ignore" }).status === 0) {
     "- Always use rg instead of grep/ls -R because it is much faster and respects gitignore",
   );
 }
+if (process.platform === "win32") {
+  const shell = process.env["PROMPT"] ? "CMD" : "PowerShell";
+  dynamicLines.push(`OS: Windows ${os.release()}`);
+  dynamicLines.push(
+    `- Provide only commands that work in a Windows environment using ${shell}`,
+  );
+}
 const dynamicPrefix = dynamicLines.join("\n");
 const prefix = `You are operating as and within the Codex CLI, a terminal-based agentic coding assistant built by OpenAI. It wraps OpenAI models to enable natural language interaction with a local codebase. You are expected to be precise, safe, and helpful.
 

--- a/codex-cli/src/utils/agent/handle-exec-command.ts
+++ b/codex-cli/src/utils/agent/handle-exec-command.ts
@@ -1,5 +1,3 @@
-
-
 import type { CommandConfirmation } from "./agent-loop.js";
 import type { ApplyPatchCommand, ApprovalPolicy } from "../../approvals.js";
 import type { AppConfig } from "../config.js";
@@ -10,10 +8,11 @@ import { canAutoApprove } from "../../approvals.js";
 import { formatCommandForDisplay } from "../../format-command.js";
 import { FullAutoErrorMode } from "../auto-approval-mode.js";
 import { exec, execApplyPatch } from "./exec.js";
+import { adaptCommandForPlatform } from "./platform-commands.js";
 import { ReviewDecision } from "./review.js";
-import { isLoggingEnabled, log } from "../logger/log.js";
 import { SandboxType } from "./sandbox/interface.js";
 import { PATH_TO_SEATBELT_EXECUTABLE } from "./sandbox/macos-seatbelt.js";
+import { isLoggingEnabled, log } from "../logger/log.js";
 import fs from "fs/promises";
 
 // ---------------------------------------------------------------------------
@@ -83,22 +82,26 @@ export async function handleExecCommand(
     applyPatch: ApplyPatchCommand | undefined,
   ) => Promise<CommandConfirmation>,
   abortSignal?: AbortSignal,
-  ): Promise<HandleExecCommandResult> {
-  const { cmd: command, workdir } = args;
+): Promise<HandleExecCommandResult> {
+  const { cmd: originalCommand, workdir } = args;
+  const { command, message: adaptationMessage } =
+    adaptCommandForPlatform(originalCommand);
+  const execArgs = { ...args, cmd: command };
 
   const key = deriveCommandKey(command);
 
   // 1) If the user has already said "always approve", skip
   //    any policy & never sandbox.
   if (alwaysApprovedCommands.has(key)) {
-    return execCommand(
-      args,
+    const summary = await execCommand(
+      execArgs,
       /* applyPatch */ undefined,
       /* runInSandbox */ false,
       additionalWritableRoots,
       config,
       abortSignal,
-    ).then(convertSummaryToResult);
+    );
+    return convertSummaryToResult(summary, adaptationMessage);
   }
 
   // 2) Otherwise fall back to the normal policy
@@ -113,7 +116,7 @@ export async function handleExecCommand(
   switch (safety.type) {
     case "ask-user": {
       const review = await askUserPermission(
-        args,
+        execArgs,
         safety.applyPatch,
         getCommandConfirmation,
       );
@@ -141,7 +144,7 @@ export async function handleExecCommand(
 
   const { applyPatch } = safety;
   const summary = await execCommand(
-    args,
+    execArgs,
     applyPatch,
     runInSandbox,
     additionalWritableRoots,
@@ -169,7 +172,7 @@ export async function handleExecCommand(
     config.fullAutoErrorMode === FullAutoErrorMode.ASK_USER
   ) {
     const review = await askUserPermission(
-      args,
+      execArgs,
       safety.applyPatch,
       getCommandConfirmation,
     );
@@ -179,31 +182,42 @@ export async function handleExecCommand(
       // The user has approved the command, so we will run it outside of the
       // sandbox.
       const summary = await execCommand(
-        args,
+        execArgs,
         applyPatch,
         false,
         additionalWritableRoots,
         config,
         abortSignal,
       );
-      return convertSummaryToResult(summary);
+      return convertSummaryToResult(summary, adaptationMessage);
     }
   } else {
-    return convertSummaryToResult(summary);
+    return convertSummaryToResult(summary, adaptationMessage);
   }
 }
 
 function convertSummaryToResult(
   summary: ExecCommandSummary,
+  adaptationMessage?: string,
 ): HandleExecCommandResult {
   const { stdout, stderr, exitCode, durationMs } = summary;
-  return {
+  const result: HandleExecCommandResult = {
     outputText: stdout || stderr,
     metadata: {
       exit_code: exitCode,
       duration_seconds: Math.round(durationMs / 100) / 10,
     },
   };
+  if (adaptationMessage) {
+    result.additionalItems = [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: adaptationMessage }],
+      },
+    ];
+  }
+  return result;
 }
 
 type ExecCommandSummary = {
@@ -245,8 +259,8 @@ async function execCommand(
       `EXEC running \`${formatCommandForDisplay(
         cmd,
       )}\` in workdir=${workdir} with timeout=${timeout}s`,
-          );
-        }
+    );
+  }
 
   // Note execApplyPatch() and exec() are coded defensively and should not
   // throw. Any internal errors should be mapped to a non-zero value for the
@@ -255,12 +269,12 @@ async function execCommand(
   const execResult =
     applyPatchCommand != null
       ? execApplyPatch(applyPatchCommand.patch, workdir)
-        : await exec(
-            { ...execInput, additionalWritableRoots },
-            await getSandbox(runInSandbox, config.allowNoSandbox ?? false),
-            config,
-            abortSignal,
-          );
+      : await exec(
+          { ...execInput, additionalWritableRoots },
+          await getSandbox(runInSandbox, config.allowNoSandbox ?? false),
+          config,
+          abortSignal,
+        );
   const duration = Date.now() - start;
   const { stdout, stderr, exitCode } = execResult;
 

--- a/codex-cli/src/utils/agent/platform-commands.ts
+++ b/codex-cli/src/utils/agent/platform-commands.ts
@@ -3,6 +3,9 @@
  */
 
 import { log } from "../logger/log.js";
+import { spawnSync } from "child_process";
+import path from "path";
+import { fileURLToPath } from "url";
 
 // On Windows, many useful commands are implemented as shell built-ins rather
 // than standalone executables. `COMSPEC` points to the command interpreter
@@ -46,35 +49,60 @@ const OPTION_MAP: Record<string, Record<string, string>> = {
  * @param command The command array to adapt
  * @returns The adapted command array
  */
-export function adaptCommandForPlatform(command: Array<string>): Array<string> {
+export function adaptCommandForPlatform(command: Array<string>): {
+  command: Array<string>;
+  message?: string;
+} {
   // If not on Windows, return the original command
   if (process.platform !== "win32") {
-    return command;
+    return { command };
   }
 
   // Nothing to adapt if the command is empty
   if (command.length === 0) {
-    return command;
+    return { command };
   }
 
+  try {
+    const __filename = fileURLToPath(import.meta.url);
+    const scriptPath = path.join(
+      path.dirname(__filename),
+      "../../scripts/command_validator.py",
+    );
+    const result = spawnSync("python", [scriptPath, JSON.stringify(command)], {
+      encoding: "utf-8",
+    });
+    if (result.status === 0 && result.stdout) {
+      const parsed = JSON.parse(result.stdout.trim());
+      if (Array.isArray(parsed.command)) {
+        return { command: parsed.command, message: parsed.message };
+      }
+    } else if (result.stderr) {
+      log(`command_validator stderr: ${result.stderr}`);
+    }
+  } catch (err) {
+    log(`command_validator failed: ${String(err)}`);
+  }
+
+  // Fallback to simple mapping
   const cmd = command[0];
 
   // Special cases for commands that are Windows shell built-ins.
   if (cmd === "pwd") {
-    log("Adapting command 'pwd' for Windows platform");
-    return [COMSPEC, "/c", "cd"];
+    log("Adapting command 'pwd' for Windows platform (fallback)");
+    return { command: [COMSPEC, "/c", "cd"], message: undefined };
   }
   if (cmd === "env" || cmd === "printenv") {
-    log(`Adapting command '${cmd}' for Windows platform`);
-    return [COMSPEC, "/c", "set"];
+    log(`Adapting command '${cmd}' for Windows platform (fallback)`);
+    return { command: [COMSPEC, "/c", "set"], message: undefined };
   }
 
   // If cmd is undefined or the command doesn't need adaptation, return it as is
   if (!cmd || !COMMAND_MAP[cmd]) {
-    return command;
+    return { command };
   }
 
-  log(`Adapting command '${cmd}' for Windows platform`);
+  log(`Adapting command '${cmd}' for Windows platform (fallback)`);
 
   // Create a new command array with the adapted command
   const adaptedCommand = [...command];
@@ -91,7 +119,7 @@ export function adaptCommandForPlatform(command: Array<string>): Array<string> {
     }
   }
 
-  log(`Adapted command: ${adaptedCommand.join(" ")}`);
+  log(`Adapted command (fallback): ${adaptedCommand.join(" ")}`);
 
-  return adaptedCommand;
+  return { command: adaptedCommand };
 }

--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -8,9 +8,8 @@ import type {
   StdioPipe,
 } from "child_process";
 
-import { log } from "../../logger/log.js";
-import { adaptCommandForPlatform } from "../platform-commands.js";
 import { createTruncatingCollector } from "./create-truncating-collector";
+import { log } from "../../logger/log.js";
 import { spawn } from "child_process";
 import * as os from "os";
 
@@ -24,18 +23,7 @@ export function exec(
   config: AppConfig,
   abortSignal?: AbortSignal,
 ): Promise<ExecResult> {
-  // Adapt command for the current platform (e.g., convert 'ls' to 'dir' on Windows)
-  const adaptedCommand = adaptCommandForPlatform(command);
-
-  if (JSON.stringify(adaptedCommand) !== JSON.stringify(command)) {
-    log(
-      `Command adapted for platform: ${command.join(
-        " ",
-      )} -> ${adaptedCommand.join(" ")}`,
-    );
-  }
-
-  const prog = adaptedCommand[0];
+  const prog = command[0];
   if (typeof prog !== "string") {
     return Promise.resolve({
       stdout: "",
@@ -84,7 +72,7 @@ export function exec(
     detached: true,
   };
 
-  const child: ChildProcess = spawn(prog, adaptedCommand.slice(1), fullOptions);
+  const child: ChildProcess = spawn(prog, command.slice(1), fullOptions);
   // If an AbortSignal is provided, ensure the spawned process is terminated
   // when the signal is triggered so that cancellations propagate down to any
   // long‑running child processes. We default to SIGTERM to give the process a


### PR DESCRIPTION
## Summary
- add Python validator to translate Unix commands to Windows equivalents
- route CLI exec flow through validator and surface warnings in chat
- inject Windows OS and shell details into system context

## Testing
- `pnpm --filter @openai/codex lint`
- `pnpm --filter @openai/codex format`
- `pnpm --filter @openai/codex test` *(failed: Process with PID 6480 failed to terminate within 500ms)*


------
https://chatgpt.com/codex/tasks/task_e_68956ef0442c8329b3204a4bbe98ac9b