### PR TITLE
Fix AltGr printable handling in text buffer

### DIFF
--- a/codex-cli/src/text-buffer.ts
+++ b/codex-cli/src/text-buffer.ts
@@ -838,6 +838,13 @@ export default class TextBuffer {
       return false;
     }
 
+    const altGrPrintable =
+      Boolean(input) &&
+      key["ctrl"] &&
+      key["alt"] &&
+      !key["meta"] &&
+      isPrintableInput(input);
+
     /* new line — Ink sets either `key.return` *or* passes a literal "\n" */
     if (key["return"] || input === "\r" || input === "\n") {
       this.newline();
@@ -945,13 +952,6 @@ export default class TextBuffer {
       this.del();
     }
     // Normal input
-    const altGrPrintable =
-      Boolean(input) &&
-      key["ctrl"] &&
-      key["alt"] &&
-      !key["meta"] &&
-      isPrintableInput(input);
-
     else if (input && (!key["ctrl"] || altGrPrintable) && !key["meta"]) {
       this.insert(input);
     }


### PR DESCRIPTION
## Summary
- move the AltGr printable check before the input handling branches in the text buffer
- keep the normal input branch attached to the existing else-if chain so the build succeeds again

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e82dd59b3c8329b2c40ab1cc9d570d