### PR TITLE
Update Codex default model to o4-mini

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -75,7 +75,7 @@ const cli = meow(
     --version                       Print version and exit
 
     -h, --help                      Show usage and exit
-    -m, --model <model>             Model to use for completions (default: codex-mini-latest)
+    -m, --model <model>             Model to use for completions (default: o4-mini)
     -p, --provider <provider>       Provider to use for completions (default: openai)
     -i, --image <path>              Path(s) to image files to include as input
     -v, --view <rollout>            Inspect a previously saved rollout instead of starting a session

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -43,7 +43,7 @@ if (!isVitest) {
   loadDotenv({ path: USER_WIDE_CONFIG_PATH });
 }
 
-export const DEFAULT_AGENTIC_MODEL = "codex-mini-latest";
+export const DEFAULT_AGENTIC_MODEL = "o4-mini";
 export const DEFAULT_FULL_CONTEXT_MODEL = "gpt-4.1";
 export const DEFAULT_APPROVAL_MODE = AutoApprovalMode.SUGGEST;
 export const DEFAULT_INSTRUCTIONS = "";

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -67,7 +67,7 @@ test("loads default config if files don't exist", () => {
   });
   // Keep the test focused on just checking that default model and instructions are loaded
   // so we need to make sure we check just these properties
-  expect(config.model).toBe("codex-mini-latest");
+  expect(config.model).toBe("o4-mini");
   expect(config.instructions).toBe("");
 });
 

--- a/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+++ b/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
@@ -29,7 +29,7 @@ describe.each([
 ])("AgentLoop with disableResponseStorage=%s", ({ flag, title }) => {
   /* build a fresh config for each case */
   const cfg: AppConfig = {
-    model: "codex-mini-latest",
+    model: "o4-mini",
     provider: "openai",
     instructions: "",
     disableResponseStorage: flag,

--- a/codex-cli/tests/disableResponseStorage.test.ts
+++ b/codex-cli/tests/disableResponseStorage.test.ts
@@ -21,10 +21,7 @@ describe("disableResponseStorage persistence", () => {
     mkdirSync(codexDir, { recursive: true });
 
     // seed YAML with ZDR enabled
-    writeFileSync(
-      yamlPath,
-      "model: codex-mini-latest\ndisableResponseStorage: true\n",
-    );
+    writeFileSync(yamlPath, "model: o4-mini\ndisableResponseStorage: true\n");
   });
 
   afterAll((): void => {

--- a/codex-cli/tests/model-utils-network-error.test.ts
+++ b/codex-cli/tests/model-utils-network-error.test.ts
@@ -46,7 +46,7 @@ describe("model-utils – offline resilience", () => {
 
     const supported = await isModelSupportedForResponses(
       "openai",
-      "codex-mini-latest",
+      "o4-mini",
     );
     expect(supported).toBe(true);
   });

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -17,7 +17,7 @@ Both the `--config` flag and the `config.toml` file support the following option
 The model that Codex should use.
 
 ```toml
-model = "o3"  # overrides the default of "codex-mini-latest"
+model = "o3"  # overrides the default of "o4-mini"
 ```
 
 ## model_provider
@@ -139,7 +139,7 @@ Users can specify config values at multiple levels. Order of precedence is as fo
 1. custom command-line argument, e.g., `--model o3`
 2. as part of a profile, where the `--profile` is specified via a CLI (or in the config file itself)
 3. as an entry in `config.toml`, e.g., `model = "o3"`
-4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `codex-mini-latest`)
+4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `o4-mini`)
 
 ## model_reasoning_effort
 

--- a/codex-rs/core/src/flags.rs
+++ b/codex-rs/core/src/flags.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use env_flags::env_flags;
 
 env_flags! {
-    pub OPENAI_DEFAULT_MODEL: &str = "codex-mini-latest";
+    pub OPENAI_DEFAULT_MODEL: &str = "o4-mini";
     pub OPENAI_API_BASE: &str = "https://api.openai.com/v1";
 
     /// Fallback when the provider-specific key is not set.

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -523,7 +523,7 @@ mod tests {
             id: "1234".to_string(),
             msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
                 session_id,
-                model: "codex-mini-latest".to_string(),
+                model: "o4-mini".to_string(),
                 history_log_id: 0,
                 history_entry_count: 0,
             }),
@@ -531,7 +531,7 @@ mod tests {
         let serialized = serde_json::to_string(&event).unwrap();
         assert_eq!(
             serialized,
-            r#"{"id":"1234","msg":{"type":"session_configured","session_id":"67e55044-10b1-426f-9247-bb680e5fe0c8","model":"codex-mini-latest","history_log_id":0,"history_entry_count":0}}"#
+            r#"{"id":"1234","msg":{"type":"session_configured","session_id":"67e55044-10b1-426f-9247-bb680e5fe0c8","model":"o4-mini","history_log_id":0,"history_entry_count":0}}"#
         );
     }
 }


### PR DESCRIPTION
## Summary
- switch the CLI and runtime defaults from `codex-mini-latest` to `o4-mini`
- refresh related unit tests and Rust defaults to match the new model
- update configuration documentation to advertise the new default

## Testing
- `pnpm --filter ./codex-cli test`


------
https://chatgpt.com/codex/tasks/task_e_68e8321e38288329b8b81205bfc01379