### PR TITLE
Fix agent ref initialization order in terminal chat

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -230,6 +230,7 @@ export default function TerminalChat({
   // Keep a single AgentLoop instance alive across renders;
   // recreate only when model/instructions/approvalPolicy change.
   const agentRef = React.useRef<AgentLoop>();
+  const agent = agentRef.current;
   const [, forceUpdate] = React.useReducer((c) => c + 1, 0); // trigger re‑render
 
   // ────────────────────────────────────────────────────────────────
@@ -449,7 +450,6 @@ export default function TerminalChat({
   }, [notify, loading, confirmationPrompt, items, PWD]);
 
   // Let's also track whenever the ref becomes available.
-  const agent = agentRef.current;
   useEffect(() => {
     log(`agentRef.current is now ${Boolean(agent)}`);
   }, [agent]);


### PR DESCRIPTION
## Summary
- initialize the `agent` reference before defining hooks that reference it in the terminal chat component to avoid temporal dead zone errors when bundling

## Testing
- pnpm --filter @openai/codex build

------
https://chatgpt.com/codex/tasks/task_e_68e8351fe4508329ab231248f77f37bd