### PR TITLE
Fix quoting in Windows installer config generation

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -85,12 +85,12 @@ switch ($provider) {
     }
 }
 
-$configBody += "model = \"$model\""
-$configBody += "model_provider = \"$providerKey\""
+$configBody += "model = `"$model`""
+$configBody += "model_provider = `"$providerKey`""
 
 $configContent = ($configBody -join "`n") + "`n"
 $configPath = Join-Path $codexDir "config.toml"
-$configContent | Set-Content -Encoding UTF8
+$configContent | Set-Content -Path $configPath -Encoding UTF8
 Write-Host "Wrote configuration to $configPath" -ForegroundColor Green
 
 # Create default AGENTS.md with bilingual instructions


### PR DESCRIPTION
## Summary
- fix quoting around model configuration lines in the Windows installer script
- ensure the generated configuration is written to the intended config.toml path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e849f98f188329a39a4703214f098a