### PR TITLE
Build Codex CLI from source during Windows install

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,15 @@ they'll be committed to your working directory.
 Windows users should run [`install_windows.bat`](./install_windows.bat), which
 invokes the PowerShell installer (`scripts/install_windows.ps1`). Make sure you
 have **Node.js 22 or newer** installed first. The script verifies the version,
-updates your `PATH`, writes a default `~/.codex/AGENTS.md`, and installs the
-Rust-based Codex CLI via `npm install -g @openai/codex@native`. During setup it
-creates a `~/.codex/config.toml`, letting you choose between OpenAI, Gemini, or
-Claude via OpenRouter (and prompting for API keys when needed). A minimal Python
-helper for interactive prompts is provided at
+updates your `PATH`, writes a default `~/.codex/AGENTS.md`, and can build the
+Rust-based Codex CLI from the `codex-rs` workspace using `cargo install`. During
+setup it creates a `~/.codex/config.toml`, letting you choose between OpenAI,
+Gemini, or Claude via OpenRouter (and prompting for API keys when needed). A
+minimal Python helper for interactive prompts is provided at
 [`scripts/windows_agent.py`](./scripts/windows_agent.py). **Note:** The script
-adds Node and npm's global bin folder to your PATH. If running `codex` opens the
-PowerShell script in an editor, reinstall Node.js or run the setup script again
-to fix file associations.
+adds Node, npm's global bin folder, and (when present) `~/.cargo/bin` to your
+PATH. If running `codex` opens the PowerShell script in an editor, reinstall
+Node.js or run the setup script again to fix file associations.
 
 
 ---

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -19,6 +19,9 @@ if ($env:PATH -notlike "*$nodeDir*") {
     [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$nodeDir", "User")
 }
 
+# Resolve repository root (one level above the scripts directory)
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+
 # Ensure ~/.codex exists
 $codexDir = Join-Path $env:USERPROFILE ".codex"
 if (!(Test-Path $codexDir)) {
@@ -115,19 +118,41 @@ if ($env:PATH -notlike "*$npmBin*") {
     [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$npmBin", "User")
 }
 
-# Optional CLI installation
-$respCli = Read-Host "Install Codex CLI now? [Y/n]"
+# Optional Rust CLI build
+$respCli = Read-Host "Build the Codex CLI from source now? [Y/n]"
 if ($respCli -match '^[Yy]' -or $respCli -eq '') {
-    try {
-        npm install -g @openai/codex@native | Out-Null
-        $codexCmd = Get-Command codex -ErrorAction SilentlyContinue
-        if (-not $codexCmd) {
-            Write-Host "CLI installed but 'codex' not found in PATH. Restart your terminal or check npm prefix." -ForegroundColor Yellow
+    $cargo = Get-Command cargo -ErrorAction SilentlyContinue
+    if (-not $cargo) {
+        Write-Host "Rust toolchain not found. Install it from https://rustup.rs and re-run this step." -ForegroundColor Red
+    } else {
+        $cliCrate = Join-Path (Join-Path $repoRoot "codex-rs") "cli"
+        if (-not (Test-Path $cliCrate)) {
+            Write-Host "Could not locate Codex CLI crate at $cliCrate" -ForegroundColor Red
         } else {
-            Write-Host "Codex CLI installed" -ForegroundColor Green
+            $exitCode = 0
+            Push-Location $repoRoot
+            try {
+                Write-Host "Building Codex CLI (this may take a few minutes)..." -ForegroundColor Cyan
+                & $cargo.Source install --path $cliCrate --locked --force
+                $exitCode = $LASTEXITCODE
+            } catch {
+                $exitCode = 1
+                Write-Host "Failed to invoke cargo: $_" -ForegroundColor Red
+            } finally {
+                Pop-Location
+            }
+
+            if ($exitCode -eq 0) {
+                $cargoBin = Join-Path $env:USERPROFILE ".cargo\bin"
+                Write-Host "Codex CLI installed to $cargoBin" -ForegroundColor Green
+                if ($env:PATH -notlike "*$cargoBin*") {
+                    Write-Host "Adding ~/.cargo/bin to PATH" -ForegroundColor Yellow
+                    [Environment]::SetEnvironmentVariable("PATH", $env:PATH + ";$cargoBin", "User")
+                }
+            } else {
+                Write-Host "Cargo reported a non-zero exit code ($exitCode)." -ForegroundColor Red
+            }
         }
-    } catch {
-        Write-Host "Failed to install Codex CLI: $_" -ForegroundColor Red
     }
 }
 


### PR DESCRIPTION
## Summary
- update the Windows PowerShell installer to compile and install the Rust-based Codex CLI with `cargo install`
- document the new Windows installation flow in the README, including PATH updates for the Rust toolchain

## Testing
- not run (PowerShell is not available in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68e8502801c4832993fbdd3917cc539b