### PR TITLE
Adjust interrupt handling and composer injection

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -996,6 +996,7 @@ impl CodexMessageProcessor {
         let _ = conversation
             .submit(Op::UserInput {
                 items: mapped_items,
+                intervention: None,
             })
             .await;
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -79,6 +79,7 @@ use crate::protocol::ExecApprovalRequestEvent;
 use crate::protocol::ExecCommandBeginEvent;
 use crate::protocol::ExecCommandEndEvent;
 use crate::protocol::InputItem;
+use crate::protocol::InterventionMode;
 use crate::protocol::ListCustomPromptsResponseEvent;
 use crate::protocol::Op;
 use crate::protocol::PatchApplyBeginEvent;
@@ -98,6 +99,7 @@ use crate::rollout::RolloutRecorder;
 use crate::rollout::RolloutRecorderParams;
 use crate::shell;
 use crate::state::ActiveTurn;
+use crate::state::PendingUserInput;
 use crate::state::SessionServices;
 use crate::tasks::CompactTask;
 use crate::tasks::RegularTask;
@@ -1007,19 +1009,30 @@ impl Session {
     }
 
     /// Returns the input if there was no task running to inject into
-    pub async fn inject_input(&self, input: Vec<InputItem>) -> Result<(), Vec<InputItem>> {
+    pub async fn inject_input(
+        &self,
+        input: Vec<InputItem>,
+        intervention: Option<InterventionMode>,
+    ) -> Result<(), Vec<InputItem>> {
         let mut active = self.active_turn.lock().await;
-        match active.as_mut() {
-            Some(at) => {
-                let mut ts = at.turn_state.lock().await;
-                ts.push_pending_input(input.into());
-                Ok(())
+        if let Some(at) = active.as_mut() {
+            let mut ts = at.turn_state.lock().await;
+            ts.push_pending_input(PendingUserInput {
+                items: input,
+                intervention,
+            });
+            Ok(())
+        } else {
+            if intervention.is_some() {
+                tracing::warn!(
+                    "received intervention input with no active task; falling back to new turn"
+                );
             }
-            None => Err(input),
+            Err(input)
         }
     }
 
-    pub async fn get_pending_input(&self) -> Vec<ResponseInputItem> {
+    pub async fn get_pending_input(&self) -> Vec<PendingUserInput> {
         let mut active = self.active_turn.lock().await;
         match active.as_mut() {
             Some(at) => {
@@ -1231,13 +1244,16 @@ async fn submission_loop(
                     .await;
                 }
             }
-            Op::UserInput { items } => {
+            Op::UserInput {
+                items,
+                intervention,
+            } => {
                 turn_context
                     .client
                     .get_otel_event_manager()
                     .user_prompt(&items);
                 // attempt to inject input into current task
-                if let Err(items) = sess.inject_input(items).await {
+                if let Err(items) = sess.inject_input(items, intervention).await {
                     // no current task, spawn a new one
                     sess.spawn_task(Arc::clone(&turn_context), sub.id, items, RegularTask)
                         .await;
@@ -1258,7 +1274,7 @@ async fn submission_loop(
                     .get_otel_event_manager()
                     .user_prompt(&items);
                 // attempt to inject input into current task
-                if let Err(items) = sess.inject_input(items).await {
+                if let Err(items) = sess.inject_input(items, None).await {
                     // Derive a fresh TurnContext for this turn using the provided overrides.
                     let provider = turn_context.client.get_provider();
                     let auth_manager = turn_context.client.get_auth_manager();
@@ -1441,9 +1457,12 @@ async fn submission_loop(
             Op::Compact => {
                 // Attempt to inject input into current task
                 if let Err(items) = sess
-                    .inject_input(vec![InputItem::Text {
-                        text: compact::SUMMARIZATION_PROMPT.to_string(),
-                    }])
+                    .inject_input(
+                        vec![InputItem::Text {
+                            text: compact::SUMMARIZATION_PROMPT.to_string(),
+                        }],
+                        None,
+                    )
                     .await
                 {
                     sess.spawn_task(Arc::clone(&turn_context), sub.id, items, CompactTask)
@@ -1671,11 +1690,20 @@ pub(crate) async fn run_task(
         // Note that pending_input would be something like a message the user
         // submitted through the UI while the model was running. Though the UI
         // may support this, the model might not.
-        let pending_input = sess
+        let mut pending_interventions: Vec<(InterventionMode, ResponseInputItem)> = Vec::new();
+        let pending_input_items = sess
             .get_pending_input()
             .await
             .into_iter()
-            .map(ResponseItem::from)
+            .filter_map(|pending| {
+                let message = ResponseInputItem::from(pending.items);
+                if let Some(mode) = pending.intervention {
+                    pending_interventions.push((mode, message));
+                    None
+                } else {
+                    Some(ResponseItem::from(message))
+                }
+            })
             .collect::<Vec<ResponseItem>>();
 
         // Construct the input that we will send to the model.
@@ -1689,13 +1717,14 @@ pub(crate) async fn run_task(
         //   only record the new items that originated in this turn so that it
         //   represents an append-only log without duplicates.
         let turn_input: Vec<ResponseItem> = if is_review_mode {
-            if !pending_input.is_empty() {
-                review_thread_history.extend(pending_input);
+            if !pending_input_items.is_empty() {
+                review_thread_history.extend(pending_input_items.clone());
             }
             review_thread_history.clone()
         } else {
-            sess.record_conversation_items(&pending_input).await;
-            sess.turn_input_with_history(pending_input).await
+            sess.record_conversation_items(&pending_input_items).await;
+            sess.turn_input_with_history(pending_input_items.clone())
+                .await
         };
 
         let turn_input_messages: Vec<String> = turn_input
@@ -1863,6 +1892,40 @@ pub(crate) async fn run_task(
 
                 auto_compact_recently_attempted = false;
 
+                let mut intervention_history_items: Vec<ResponseItem> = Vec::new();
+                let mut intervention_responses: Vec<ResponseInputItem> = Vec::new();
+                let mut saw_interrupt_intervention = false;
+                for (mode, pending) in pending_interventions.drain(..) {
+                    if let Some(formatted) = build_intervention_message(pending, mode) {
+                        intervention_history_items.push(ResponseItem::from(formatted.clone()));
+                        match mode {
+                            InterventionMode::Add => {
+                                intervention_responses.push(formatted);
+                            }
+                            InterventionMode::Interrupt => {
+                                saw_interrupt_intervention = true;
+                                intervention_responses.push(formatted);
+                            }
+                        }
+                    }
+                }
+
+                if saw_interrupt_intervention {
+                    responses = intervention_responses;
+                } else if !intervention_responses.is_empty() {
+                    responses.extend(intervention_responses);
+                }
+
+                if !intervention_history_items.is_empty() {
+                    if saw_interrupt_intervention {
+                        let mut combined = intervention_history_items;
+                        combined.extend(items_to_record_in_conversation_history);
+                        items_to_record_in_conversation_history = combined;
+                    } else {
+                        items_to_record_in_conversation_history.extend(intervention_history_items);
+                    }
+                }
+
                 if responses.is_empty() {
                     last_agent_message = get_last_assistant_message_from_turn(
                         &items_to_record_in_conversation_history,
@@ -1933,6 +1996,56 @@ fn parse_review_output_event(text: &str) -> ReviewOutputEvent {
     ReviewOutputEvent {
         overall_explanation: text.to_string(),
         ..Default::default()
+    }
+}
+
+fn build_intervention_message(
+    pending: ResponseInputItem,
+    mode: InterventionMode,
+) -> Option<ResponseInputItem> {
+    if let ResponseInputItem::Message { role, content } = pending {
+        let mut text_segments = Vec::new();
+        let mut attachments = Vec::new();
+        for item in content {
+            match item {
+                ContentItem::InputText { text } => text_segments.push(text),
+                other => attachments.push(other),
+            }
+        }
+        let combined_text = text_segments.join("\n");
+        let trimmed_text = combined_text.trim();
+        let decorated = match mode {
+            InterventionMode::Add => {
+                if trimmed_text.is_empty() {
+                    "But wait, the user wants you to know also. Please take that into account before continuing.".to_string()
+                } else {
+                    format!(
+                        "But wait, the user wants you to know also:\n{trimmed}\nPlease take that into account before continuing.",
+                        trimmed = trimmed_text
+                    )
+                }
+            }
+            InterventionMode::Interrupt => {
+                if trimmed_text.is_empty() {
+                    "Before you had the chance to receive the output of this command, the user interrupted with an additional note. Consider that first before continuing.".to_string()
+                } else {
+                    format!(
+                        "Before you had the chance to receive the output of this command, the user interrupted to add:\n{trimmed}\nConsider that first before continuing.",
+                        trimmed = trimmed_text
+                    )
+                }
+            }
+        };
+
+        let mut new_content = Vec::with_capacity(1 + attachments.len());
+        new_content.push(ContentItem::InputText { text: decorated });
+        new_content.extend(attachments);
+        Some(ResponseInputItem::Message {
+            role,
+            content: new_content,
+        })
+    } else {
+        None
     }
 }
 

--- a/codex-rs/core/src/state/mod.rs
+++ b/codex-rs/core/src/state/mod.rs
@@ -5,5 +5,6 @@ mod turn;
 pub(crate) use service::SessionServices;
 pub(crate) use session::SessionState;
 pub(crate) use turn::ActiveTurn;
+pub(crate) use turn::PendingUserInput;
 pub(crate) use turn::RunningTask;
 pub(crate) use turn::TaskKind;

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::task::AbortHandle;
 
-use codex_protocol::models::ResponseInputItem;
+use codex_protocol::protocol::InputItem;
+use codex_protocol::protocol::InterventionMode;
 use tokio::sync::oneshot;
 
 use crate::protocol::ReviewDecision;
@@ -60,7 +61,13 @@ impl ActiveTurn {
 #[derive(Default)]
 pub(crate) struct TurnState {
     pending_approvals: HashMap<String, oneshot::Sender<ReviewDecision>>,
-    pending_input: Vec<ResponseInputItem>,
+    pending_input: Vec<PendingUserInput>,
+}
+
+#[derive(Clone)]
+pub(crate) struct PendingUserInput {
+    pub(crate) items: Vec<InputItem>,
+    pub(crate) intervention: Option<InterventionMode>,
 }
 
 impl TurnState {
@@ -84,11 +91,11 @@ impl TurnState {
         self.pending_input.clear();
     }
 
-    pub(crate) fn push_pending_input(&mut self, input: ResponseInputItem) {
+    pub(crate) fn push_pending_input(&mut self, input: PendingUserInput) {
         self.pending_input.push(input);
     }
 
-    pub(crate) fn take_pending_input(&mut self) -> Vec<ResponseInputItem> {
+    pub(crate) fn take_pending_input(&mut self) -> Vec<PendingUserInput> {
         if self.pending_input.is_empty() {
             Vec::with_capacity(0)
         } else {

--- a/codex-rs/core/src/tools/handlers/view_image.rs
+++ b/codex-rs/core/src/tools/handlers/view_image.rs
@@ -67,7 +67,7 @@ impl ToolHandler for ViewImageHandler {
         let event_path = abs_path.clone();
 
         session
-            .inject_input(vec![InputItem::LocalImage { path: abs_path }])
+            .inject_input(vec![InputItem::LocalImage { path: abs_path }], None)
             .await
             .map_err(|_| {
                 FunctionCallError::RespondToModel(

--- a/codex-rs/core/tests/suite/abort_tasks.rs
+++ b/codex-rs/core/tests/suite/abort_tasks.rs
@@ -45,6 +45,7 @@ async fn interrupt_long_running_tool_emits_turn_aborted() {
             items: vec![InputItem::Text {
                 text: "start sleep".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -266,6 +266,7 @@ async fn resume_includes_initial_messages_and_sends_prior_items() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -338,6 +339,7 @@ async fn includes_conversation_id_and_model_headers_in_request() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -393,6 +395,7 @@ async fn includes_base_instructions_override_in_request() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -453,6 +456,7 @@ async fn chatgpt_auth_sends_correct_request() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -543,6 +547,7 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -582,6 +587,7 @@ async fn includes_user_instructions_message_in_request() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -797,6 +803,7 @@ async fn token_count_includes_rate_limits_snapshot() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -948,6 +955,7 @@ async fn usage_limit_error_emits_rate_limit_event() -> anyhow::Result<()> {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .expect("submission should succeed while emitting usage limit error events");
@@ -1016,6 +1024,7 @@ async fn context_window_error_sets_total_tokens_to_model_window() -> anyhow::Res
             items: vec![InputItem::Text {
                 text: "seed turn".into(),
             }],
+            intervention: None,
         })
         .await?;
 
@@ -1026,6 +1035,7 @@ async fn context_window_error_sets_total_tokens_to_model_window() -> anyhow::Res
             items: vec![InputItem::Text {
                 text: "trigger context window".into(),
             }],
+            intervention: None,
         })
         .await?;
 
@@ -1143,6 +1153,7 @@ async fn azure_overrides_assign_properties_used_for_responses_url() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -1220,6 +1231,7 @@ async fn env_var_overrides_loaded_auth() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -1296,6 +1308,7 @@ async fn history_dedupes_streamed_and_final_messages_across_turns() {
     codex
         .submit(Op::UserInput {
             items: vec![InputItem::Text { text: "U1".into() }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -1305,6 +1318,7 @@ async fn history_dedupes_streamed_and_final_messages_across_turns() {
     codex
         .submit(Op::UserInput {
             items: vec![InputItem::Text { text: "U2".into() }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -1314,6 +1328,7 @@ async fn history_dedupes_streamed_and_final_messages_across_turns() {
     codex
         .submit(Op::UserInput {
             items: vec![InputItem::Text { text: "U3".into() }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -109,6 +109,7 @@ async fn summarize_context_three_requests_and_instructions() {
             items: vec![InputItem::Text {
                 text: "hello world".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -124,6 +125,7 @@ async fn summarize_context_three_requests_and_instructions() {
             items: vec![InputItem::Text {
                 text: THIRD_USER_MSG.into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -325,6 +327,7 @@ async fn auto_compact_runs_after_token_limit_hit() {
             items: vec![InputItem::Text {
                 text: FIRST_AUTO_MSG.into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -336,6 +339,7 @@ async fn auto_compact_runs_after_token_limit_hit() {
             items: vec![InputItem::Text {
                 text: SECOND_AUTO_MSG.into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -469,6 +473,7 @@ async fn auto_compact_persists_rollout_entries() {
             items: vec![InputItem::Text {
                 text: FIRST_AUTO_MSG.into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -479,6 +484,7 @@ async fn auto_compact_persists_rollout_entries() {
             items: vec![InputItem::Text {
                 text: SECOND_AUTO_MSG.into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -581,6 +587,7 @@ async fn auto_compact_stops_after_failed_attempt() {
             items: vec![InputItem::Text {
                 text: FIRST_AUTO_MSG.into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -675,6 +682,7 @@ async fn manual_compact_retries_after_context_window_error() {
             items: vec![InputItem::Text {
                 text: "first turn".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -803,6 +811,7 @@ async fn auto_compact_allows_multiple_attempts_when_interleaved_with_other_turn_
             items: vec![InputItem::Text {
                 text: MULTI_AUTO_MSG.into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -778,6 +778,7 @@ async fn user_turn(conversation: &Arc<CodexConversation>, text: &str) {
     conversation
         .submit(Op::UserInput {
             items: vec![InputItem::Text { text: text.into() }],
+            intervention: None,
         })
         .await
         .expect("submit user turn");

--- a/codex-rs/core/tests/suite/fork_conversation.rs
+++ b/codex-rs/core/tests/suite/fork_conversation.rs
@@ -74,6 +74,7 @@ async fn fork_conversation_twice_drops_to_first_message() {
                 items: vec![InputItem::Text {
                     text: text.to_string(),
                 }],
+                intervention: None,
             })
             .await
             .unwrap();

--- a/codex-rs/core/tests/suite/model_tools.rs
+++ b/codex-rs/core/tests/suite/model_tools.rs
@@ -76,6 +76,7 @@ async fn collect_tool_identifiers_for_model(model: &str) -> Vec<String> {
             items: vec![InputItem::Text {
                 text: "hello tools".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/otel.rs
+++ b/codex-rs/core/tests/suite/otel.rs
@@ -34,6 +34,7 @@ async fn responses_api_emits_api_request_event() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -80,6 +81,7 @@ async fn process_sse_emits_tracing_for_output_item() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -124,6 +126,7 @@ async fn process_sse_emits_failed_event_on_parse_error() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -169,6 +172,7 @@ async fn process_sse_records_failed_event_when_stream_closes_without_completed()
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -226,6 +230,7 @@ async fn process_sse_failed_event_records_response_error_message() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -281,6 +286,7 @@ async fn process_sse_failed_event_logs_parse_error() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -331,6 +337,7 @@ async fn process_sse_failed_event_logs_missing_error() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -381,6 +388,7 @@ async fn process_sse_failed_event_logs_response_completed_parse_error() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -436,6 +444,7 @@ async fn process_sse_emits_completed_telemetry() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -496,6 +505,7 @@ async fn handle_response_item_records_tool_result_for_custom_tool_call() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -560,6 +570,7 @@ async fn handle_response_item_records_tool_result_for_function_call() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -634,6 +645,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -692,6 +704,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_call() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -790,6 +803,7 @@ async fn handle_container_exec_autoapprove_from_config_records_tool_decision() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -840,6 +854,7 @@ async fn handle_container_exec_user_approved_records_tool_decision() {
             items: vec![InputItem::Text {
                 text: "approved".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -906,6 +921,7 @@ async fn handle_container_exec_user_approved_for_session_records_tool_decision()
             items: vec![InputItem::Text {
                 text: "persist".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -972,6 +988,7 @@ async fn handle_sandbox_error_user_approves_retry_records_tool_decision() {
             items: vec![InputItem::Text {
                 text: "retry".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -1034,6 +1051,7 @@ async fn handle_container_exec_user_denies_records_tool_decision() {
             items: vec![InputItem::Text {
                 text: "deny".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -1100,6 +1118,7 @@ async fn handle_sandbox_error_user_approves_for_session_records_tool_decision() 
             items: vec![InputItem::Text {
                 text: "persist".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -1162,6 +1181,7 @@ async fn handle_sandbox_error_user_denies_records_tool_decision() {
             items: vec![InputItem::Text {
                 text: "deny".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -117,6 +117,7 @@ async fn codex_mini_latest_tools() {
             items: vec![InputItem::Text {
                 text: "hello 1".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -127,6 +128,7 @@ async fn codex_mini_latest_tools() {
             items: vec![InputItem::Text {
                 text: "hello 2".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -201,6 +203,7 @@ async fn prompt_tools_are_consistent_across_requests() {
             items: vec![InputItem::Text {
                 text: "hello 1".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -211,6 +214,7 @@ async fn prompt_tools_are_consistent_across_requests() {
             items: vec![InputItem::Text {
                 text: "hello 2".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -303,6 +307,7 @@ async fn prefixes_context_and_instructions_once_and_consistently_across_requests
             items: vec![InputItem::Text {
                 text: "hello 1".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -313,6 +318,7 @@ async fn prefixes_context_and_instructions_once_and_consistently_across_requests
             items: vec![InputItem::Text {
                 text: "hello 2".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -423,6 +429,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() {
             items: vec![InputItem::Text {
                 text: "hello 1".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -452,6 +459,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() {
             items: vec![InputItem::Text {
                 text: "hello 2".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -551,6 +559,7 @@ async fn per_turn_overrides_keep_cached_prefix_and_key_constant() {
             items: vec![InputItem::Text {
                 text: "hello 1".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -569,6 +569,7 @@ async fn review_history_does_not_leak_into_parent_session() {
             items: vec![InputItem::Text {
                 text: followup.clone(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
+++ b/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
@@ -90,6 +90,7 @@ async fn continue_after_stream_error() {
             items: vec![InputItem::Text {
                 text: "first message".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();
@@ -117,6 +118,7 @@ async fn continue_after_stream_error() {
             items: vec![InputItem::Text {
                 text: "follow up".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -97,6 +97,7 @@ async fn retries_on_early_close() {
             items: vec![InputItem::Text {
                 text: "hello".into(),
             }],
+            intervention: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/user_notification.rs
+++ b/codex-rs/core/tests/suite/user_notification.rs
@@ -55,6 +55,7 @@ echo -n "${@: -1}" > $(dirname "${0}")/notify.txt"#,
             items: vec![InputItem::Text {
                 text: "hello world".into(),
             }],
+            intervention: None,
         })
         .await?;
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -320,7 +320,12 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
             .into_iter()
             .map(|path| InputItem::LocalImage { path })
             .collect();
-        let initial_images_event_id = conversation.submit(Op::UserInput { items }).await?;
+        let initial_images_event_id = conversation
+            .submit(Op::UserInput {
+                items,
+                intervention: None,
+            })
+            .await?;
         info!("Sent images with event ID: {initial_images_event_id}");
         while let Ok(event) = conversation.next_event().await {
             if event.id == initial_images_event_id

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -94,6 +94,7 @@ pub async fn run_codex_tool_session(
             items: vec![InputItem::Text {
                 text: initial_prompt.clone(),
             }],
+            intervention: None,
         },
     };
 
@@ -128,6 +129,7 @@ pub async fn run_codex_tool_session_reply(
     if let Err(e) = conversation
         .submit(Op::UserInput {
             items: vec![InputItem::Text { text: prompt }],
+            intervention: None,
         })
         .await
     {

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -60,6 +60,9 @@ pub enum Op {
     UserInput {
         /// User input items, see `InputItem`
         items: Vec<InputItem>,
+        /// Optional user intervention metadata applied while a task is running.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        intervention: Option<InterventionMode>,
     },
 
     /// Similar to [`Op::UserInput`], but contains additional context required
@@ -405,6 +408,13 @@ pub enum InputItem {
     LocalImage {
         path: std::path::PathBuf,
     },
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum InterventionMode {
+    Add,
+    Interrupt,
 }
 
 /// Event Queue Entry - events from agent

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -317,6 +317,9 @@ impl App {
             AppEvent::UpdateReasoningEffort(effort) => {
                 self.on_update_reasoning_effort(effort);
             }
+            AppEvent::UpdateInterruptMode(enabled) => {
+                self.chat_widget.set_interrupt_mode_enabled(enabled);
+            }
             AppEvent::UpdateModel(model) => {
                 self.chat_widget.set_model(&model);
                 self.config.model = model.clone();

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -52,6 +52,9 @@ pub(crate) enum AppEvent {
     /// Update the current reasoning effort in the running app and widget.
     UpdateReasoningEffort(Option<ReasoningEffort>),
 
+    /// Enable or disable interrupt mode in the chat widget.
+    UpdateInterruptMode(bool),
+
     /// Update the current model slug in the running app and widget.
     UpdateModel(String),
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -55,6 +55,7 @@ use codex_file_search::FileMatch;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
+use std::ops::Range;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Child;
@@ -64,10 +65,12 @@ use std::time::Duration;
 use std::time::Instant;
 use tracing::warn;
 use unicode_width::UnicodeWidthStr;
+use url::Url;
 
 /// If the pasted content exceeds this number of characters, replace it with a
 /// placeholder in the UI.
 const LARGE_PASTE_CHAR_THRESHOLD: usize = 1000;
+const IMAGE_EXTENSIONS: [&str; 7] = [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".svg"];
 
 /// Result returned when the user interacts with the text area.
 #[derive(Debug, PartialEq)]
@@ -82,6 +85,40 @@ struct AttachedImage {
     placeholder: String,
     path: PathBuf,
     element_id: u64,
+}
+
+#[derive(Clone, Debug)]
+struct DetectedImage {
+    placeholder: String,
+    element_id: u64,
+    source: ImagePreviewSource,
+}
+
+#[derive(Clone, Debug)]
+struct DetectedImageCandidate {
+    range: Range<usize>,
+    placeholder: String,
+    source: ImagePreviewSource,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ImageEntryMeta {
+    kind: ImageSelectionKind,
+    index: usize,
+    element_id: u64,
+    start: usize,
+}
+
+struct SelectedImageEntry {
+    placeholder: String,
+    element_id: u64,
+    source: ImagePreviewSource,
+}
+
+#[derive(Clone, Debug)]
+enum ImagePreviewSource {
+    Path(PathBuf),
+    Url(String),
 }
 
 enum PromptSelectionMode {
@@ -108,8 +145,15 @@ struct InterruptUiState {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct AttachmentSelection {
+    kind: ImageSelectionKind,
     index: usize,
     element_id: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ImageSelectionKind {
+    Attached,
+    Detected,
 }
 
 struct PreviewHandle {
@@ -131,6 +175,7 @@ pub(crate) struct ChatComposer {
     pending_pastes: Vec<(String, String)>,
     has_focus: bool,
     attached_images: Vec<AttachedImage>,
+    detected_images: Vec<DetectedImage>,
     selected_attachment: Option<AttachmentSelection>,
     preview: Option<PreviewHandle>,
     preview_active: bool,
@@ -180,6 +225,7 @@ impl ChatComposer {
             pending_pastes: Vec::new(),
             has_focus: has_input_focus,
             attached_images: Vec::new(),
+            detected_images: Vec::new(),
             selected_attachment: None,
             preview: None,
             preview_active: false,
@@ -309,6 +355,7 @@ impl ChatComposer {
         } else {
             self.sync_file_search_popup();
         }
+        self.refresh_detected_images();
         true
     }
 
@@ -356,6 +403,7 @@ impl ChatComposer {
         self.textarea.set_cursor(0);
         self.sync_command_popup();
         self.sync_file_search_popup();
+        self.refresh_detected_images();
     }
 
     /// Get the current composer text.
@@ -383,6 +431,224 @@ impl ChatComposer {
         images.into_iter().map(|img| img.path).collect()
     }
 
+    fn refresh_detected_images(&mut self) {
+        if matches!(
+            self.selected_attachment,
+            Some(selection) if selection.kind == ImageSelectionKind::Detected
+        ) {
+            self.clear_selected_attachment();
+        }
+
+        for detected in self.detected_images.drain(..) {
+            let _ = self.textarea.remove_element(detected.element_id);
+        }
+
+        let text = self.textarea.text();
+        if text.is_empty() {
+            return;
+        }
+
+        for candidate in Self::scan_for_image_tokens(text) {
+            if self.textarea.range_overlaps_element(&candidate.range) {
+                continue;
+            }
+            if let Some(element_id) = self
+                .textarea
+                .create_element_for_range(candidate.range.clone())
+            {
+                self.detected_images.push(DetectedImage {
+                    placeholder: candidate.placeholder,
+                    element_id,
+                    source: candidate.source,
+                });
+            }
+        }
+
+        self.reconcile_selected_attachment();
+    }
+
+    fn scan_for_image_tokens(text: &str) -> Vec<DetectedImageCandidate> {
+        let mut out = Vec::new();
+        let mut token_start: Option<usize> = None;
+
+        for (idx, ch) in text.char_indices() {
+            if ch.is_whitespace() {
+                if let Some(start) = token_start.take()
+                    && let Some(candidate) = Self::token_candidate(text, start, idx)
+                {
+                    out.push(candidate);
+                }
+            } else if token_start.is_none() {
+                token_start = Some(idx);
+            }
+        }
+
+        if let Some(start) = token_start
+            && let Some(candidate) = Self::token_candidate(text, start, text.len())
+        {
+            out.push(candidate);
+        }
+
+        out
+    }
+
+    fn token_candidate(text: &str, start: usize, end: usize) -> Option<DetectedImageCandidate> {
+        let (trim_start, trim_end) = Self::trim_token_bounds(text, start, end)?;
+        let token = &text[trim_start..trim_end];
+        if token.is_empty() {
+            return None;
+        }
+        if token.starts_with('[') {
+            let lower = token.to_ascii_lowercase();
+            if lower.starts_with("[image ") {
+                return None;
+            }
+        }
+
+        let source = Self::classify_image_source(token)?;
+        Some(DetectedImageCandidate {
+            range: trim_start..trim_end,
+            placeholder: token.to_string(),
+            source,
+        })
+    }
+
+    fn trim_token_bounds(text: &str, start: usize, end: usize) -> Option<(usize, usize)> {
+        if start >= end || end > text.len() {
+            return None;
+        }
+        let mut trim_start = start;
+        let mut trim_end = end;
+
+        while trim_start < trim_end {
+            let Some(ch) = text[trim_start..].chars().next() else {
+                break;
+            };
+            if matches!(ch, '(' | '[' | '{' | '<' | '"' | '\'') {
+                trim_start += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        while trim_end > trim_start {
+            let Some(ch) = text[..trim_end].chars().next_back() else {
+                break;
+            };
+            if matches!(
+                ch,
+                '.' | ',' | '!' | '?' | ':' | ';' | ')' | ']' | '}' | '>' | '"' | '\''
+            ) {
+                trim_end -= ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        if trim_start >= trim_end {
+            None
+        } else {
+            Some((trim_start, trim_end))
+        }
+    }
+
+    fn classify_image_source(token: &str) -> Option<ImagePreviewSource> {
+        if let Ok(url) = Url::parse(token) {
+            match url.scheme() {
+                "http" | "https" => {
+                    if Self::url_has_image_extension(&url) {
+                        return Some(ImagePreviewSource::Url(token.to_string()));
+                    }
+                }
+                "file" => {
+                    if let Ok(path) = url.to_file_path()
+                        && Self::str_has_image_extension(path.to_string_lossy().as_ref())
+                    {
+                        return Some(ImagePreviewSource::Path(path));
+                    }
+                }
+                _ => {}
+            }
+            return None;
+        }
+
+        if token.starts_with("http://") || token.starts_with("https://") {
+            return None;
+        }
+
+        if Self::str_has_image_extension(token) {
+            return Some(ImagePreviewSource::Path(PathBuf::from(token)));
+        }
+
+        None
+    }
+
+    fn str_has_image_extension(input: &str) -> bool {
+        let base = input
+            .split(['?', '#'])
+            .next()
+            .unwrap_or(input)
+            .to_ascii_lowercase();
+        IMAGE_EXTENSIONS.iter().any(|ext| base.ends_with(ext))
+    }
+
+    fn url_has_image_extension(url: &Url) -> bool {
+        if let Some(mut segments) = url.path_segments()
+            && let Some(last) = segments.next_back()
+        {
+            return Self::str_has_image_extension(last);
+        }
+        false
+    }
+
+    fn ordered_image_entries(&self) -> Vec<ImageEntryMeta> {
+        let mut entries: Vec<ImageEntryMeta> = Vec::new();
+        for (index, image) in self.attached_images.iter().enumerate() {
+            if let Some(range) = self.textarea.element_range(image.element_id) {
+                entries.push(ImageEntryMeta {
+                    kind: ImageSelectionKind::Attached,
+                    index,
+                    element_id: image.element_id,
+                    start: range.start,
+                });
+            }
+        }
+        for (index, image) in self.detected_images.iter().enumerate() {
+            if let Some(range) = self.textarea.element_range(image.element_id) {
+                entries.push(ImageEntryMeta {
+                    kind: ImageSelectionKind::Detected,
+                    index,
+                    element_id: image.element_id,
+                    start: range.start,
+                });
+            }
+        }
+        entries.sort_by_key(|entry| entry.start);
+        entries
+    }
+
+    fn selected_image_entry(&self) -> Option<SelectedImageEntry> {
+        let selection = self.selected_attachment?;
+        match selection.kind {
+            ImageSelectionKind::Attached => {
+                let image = self.attached_images.get(selection.index)?;
+                Some(SelectedImageEntry {
+                    placeholder: image.placeholder.clone(),
+                    element_id: image.element_id,
+                    source: ImagePreviewSource::Path(image.path.clone()),
+                })
+            }
+            ImageSelectionKind::Detected => {
+                let image = self.detected_images.get(selection.index)?;
+                Some(SelectedImageEntry {
+                    placeholder: image.placeholder.clone(),
+                    element_id: image.element_id,
+                    source: image.source.clone(),
+                })
+            }
+        }
+    }
+
     fn selection_display_for(placeholder: &str) -> String {
         let target_width = UnicodeWidthStr::width(placeholder);
         let base = "[SHOW]";
@@ -396,16 +662,29 @@ impl ChatComposer {
 
     fn selection_style() -> Style {
         Style::default()
-            .fg(Color::Rgb(255, 178, 102))
+            .fg(Color::Yellow)
             .add_modifier(Modifier::BOLD)
     }
 
-    fn apply_selection_visuals(&mut self, index: usize) -> bool {
-        let Some(image) = self.attached_images.get(index) else {
-            return false;
+    fn apply_selection_visuals(&mut self, kind: ImageSelectionKind, index: usize) -> bool {
+        let (placeholder, element_id) = match kind {
+            ImageSelectionKind::Attached => {
+                let Some(image) = self.attached_images.get(index) else {
+                    return false;
+                };
+                (&image.placeholder, image.element_id)
+            }
+            ImageSelectionKind::Detected => {
+                let Some(image) = self.detected_images.get(index) else {
+                    return false;
+                };
+                (&image.placeholder, image.element_id)
+            }
         };
-        let element_id = image.element_id;
-        let display = Self::selection_display_for(&image.placeholder);
+        if !self.textarea.element_exists(element_id) {
+            return false;
+        }
+        let display = Self::selection_display_for(placeholder);
         let style = Self::selection_style();
         let _ = self.textarea.set_element_style(element_id, style);
         let _ = self.textarea.set_element_display_override(
@@ -413,35 +692,47 @@ impl ChatComposer {
             Some(display),
             Some("▸".to_string()),
         );
-        self.selected_attachment = Some(AttachmentSelection { index, element_id });
+        self.selected_attachment = Some(AttachmentSelection {
+            kind,
+            index,
+            element_id,
+        });
         true
     }
 
     fn clear_selected_attachment(&mut self) {
         self.stop_preview(false);
-        if let Some(selection) = self.selected_attachment.take() {
-            if self.textarea.element_exists(selection.element_id) {
-                let _ = self
-                    .textarea
-                    .set_element_style(selection.element_id, Style::default().fg(Color::Cyan));
-                let _ =
-                    self.textarea
-                        .set_element_display_override(selection.element_id, None, None);
-            }
+        if let Some(selection) = self.selected_attachment.take()
+            && self.textarea.element_exists(selection.element_id)
+        {
+            let _ = self
+                .textarea
+                .set_element_style(selection.element_id, Style::default().fg(Color::Cyan));
+            let _ = self
+                .textarea
+                .set_element_display_override(selection.element_id, None, None);
         }
     }
 
     fn focus_next_attachment(&mut self) -> bool {
-        if self.attached_images.is_empty() {
+        let entries = self.ordered_image_entries();
+        if entries.is_empty() {
             return false;
         }
         self.reconcile_selected_attachment();
-        let next_index = match self.selected_attachment {
-            Some(selection) => (selection.index + 1) % self.attached_images.len(),
-            None => 0,
+        let next_entry = match self.selected_attachment {
+            Some(selection) => {
+                let current_pos = entries
+                    .iter()
+                    .position(|entry| entry.element_id == selection.element_id)
+                    .unwrap_or(0);
+                let next_idx = (current_pos + 1) % entries.len();
+                entries[next_idx]
+            }
+            None => entries[0],
         };
         self.clear_selected_attachment();
-        self.apply_selection_visuals(next_index)
+        self.apply_selection_visuals(next_entry.kind, next_entry.index)
     }
 
     fn handle_attachment_tab(&mut self, key_event: &KeyEvent) -> bool {
@@ -479,27 +770,22 @@ impl ChatComposer {
         if self.preview_active {
             return true;
         }
-        let Some(selection) = self.selected_attachment else {
+        let Some(entry) = self.selected_image_entry() else {
             return false;
         };
-        let Some(image) = self
-            .attached_images
-            .iter()
-            .find(|img| img.element_id == selection.element_id)
-        else {
-            return false;
-        };
-        match self.spawn_preview_process(&image.path) {
+        let SelectedImageEntry {
+            placeholder,
+            element_id,
+            source,
+        } = entry;
+        match self.spawn_preview_process(&source) {
             Ok(child) => {
                 let _ = self.textarea.set_element_display_override(
-                    selection.element_id,
-                    Some(image.placeholder.clone()),
+                    element_id,
+                    Some(placeholder),
                     Some("»".to_string()),
                 );
-                self.preview = Some(PreviewHandle {
-                    child,
-                    element_id: selection.element_id,
-                });
+                self.preview = Some(PreviewHandle { child, element_id });
                 self.preview_active = true;
                 true
             }
@@ -520,29 +806,29 @@ impl ChatComposer {
             let _ = handle.child.kill();
             let _ = handle.child.wait();
         }
-        if revert_to_show {
-            if let Some(element_id) = element_id {
-                if self.textarea.element_exists(element_id) {
-                    if let Some(image) = self
-                        .attached_images
-                        .iter()
-                        .find(|img| img.element_id == element_id)
-                    {
-                        let display = Self::selection_display_for(&image.placeholder);
-                        let _ = self.textarea.set_element_display_override(
-                            element_id,
-                            Some(display),
-                            Some("▸".to_string()),
-                        );
-                    }
-                }
-            }
+        if revert_to_show
+            && let Some(element_id) = element_id
+            && self.textarea.element_exists(element_id)
+            && let Some(placeholder) = self.placeholder_for_element(element_id)
+        {
+            let display = Self::selection_display_for(&placeholder);
+            let _ = self.textarea.set_element_display_override(
+                element_id,
+                Some(display),
+                Some("▸".to_string()),
+            );
         }
         self.preview_active = false;
     }
 
-    fn spawn_preview_process(&self, path: &Path) -> Result<Child, String> {
+    fn spawn_preview_process(&self, source: &ImagePreviewSource) -> Result<Child, String> {
         let (cols, rows) = terminal::size().unwrap_or((120, 32));
+        let (source_kind, source_value) = match source {
+            ImagePreviewSource::Path(path) => {
+                ("path".to_string(), path.to_string_lossy().to_string())
+            }
+            ImagePreviewSource::Url(url) => ("url".to_string(), url.clone()),
+        };
         let script = r#"
 import sys
 from pathlib import Path
@@ -555,11 +841,16 @@ except Exception:
     PIL_AVAILABLE = False
 
 def main():
-    path = Path(sys.argv[1])
-    cols = int(sys.argv[2])
-    rows = int(sys.argv[3])
+    source_kind = sys.argv[1]
+    target = sys.argv[2]
+    cols = int(sys.argv[3])
+    rows = int(sys.argv[4])
     root = tk.Tk()
-    root.title(path.name)
+    if source_kind == "path":
+        path = Path(target)
+        root.title(path.name or "image preview")
+    else:
+        root.title(target)
     root.attributes('-topmost', True)
     root.resizable(False, False)
 
@@ -569,21 +860,37 @@ def main():
     max_h = max(1, int(rows * cell_h / 4))
 
     try:
-        if PIL_AVAILABLE:
-            img = Image.open(path)
+        if source_kind == "url":
+            if not PIL_AVAILABLE:
+                raise RuntimeError("previewing URLs requires Pillow support")
+            import io
+            import urllib.request
+
+            with urllib.request.urlopen(target, timeout=5) as response:
+                data = response.read()
+            img = Image.open(io.BytesIO(data))
             scale = min(max_w / img.width, max_h / img.height, 1.0)
             new_size = (max(1, int(img.width * scale)), max(1, int(img.height * scale)))
             if new_size != img.size:
                 img = img.resize(new_size, Image.LANCZOS)
             photo = ImageTk.PhotoImage(img)
         else:
-            photo = tk.PhotoImage(file=str(path))
-            width = photo.width()
-            height = photo.height()
-            scale = min(max_w / width, max_h / height, 1.0)
-            if scale < 1.0:
-                step = max(1, int(round(1 / scale)))
-                photo = photo.subsample(step, step)
+            path = Path(target)
+            if PIL_AVAILABLE:
+                img = Image.open(path)
+                scale = min(max_w / img.width, max_h / img.height, 1.0)
+                new_size = (max(1, int(img.width * scale)), max(1, int(img.height * scale)))
+                if new_size != img.size:
+                    img = img.resize(new_size, Image.LANCZOS)
+                photo = ImageTk.PhotoImage(img)
+            else:
+                photo = tk.PhotoImage(file=str(path))
+                width = photo.width()
+                height = photo.height()
+                scale = min(max_w / width, max_h / height, 1.0)
+                if scale < 1.0:
+                    step = max(1, int(round(1 / scale)))
+                    photo = photo.subsample(step, step)
     except Exception as exc:
         label = tk.Label(root, text=f"Unable to preview image: {exc}", padx=12, pady=12)
         label.pack()
@@ -604,7 +911,8 @@ if __name__ == '__main__':
             let result = command
                 .arg("-c")
                 .arg(script)
-                .arg(path.to_string_lossy().to_string())
+                .arg(&source_kind)
+                .arg(&source_value)
                 .arg(cols.to_string())
                 .arg(rows.to_string())
                 .stdin(Stdio::null())
@@ -624,12 +932,30 @@ if __name__ == '__main__':
         Err(last_error.unwrap_or_else(|| "python interpreter not found".to_string()))
     }
 
+    fn placeholder_for_element(&self, element_id: u64) -> Option<String> {
+        if let Some(image) = self
+            .attached_images
+            .iter()
+            .find(|img| img.element_id == element_id)
+        {
+            return Some(image.placeholder.clone());
+        }
+        if let Some(image) = self
+            .detected_images
+            .iter()
+            .find(|img| img.element_id == element_id)
+        {
+            return Some(image.placeholder.clone());
+        }
+        None
+    }
+
     fn python_candidates() -> Vec<String> {
         let mut out = Vec::new();
-        if let Ok(value) = env::var("PYTHON") {
-            if !value.trim().is_empty() {
-                out.push(value);
-            }
+        if let Ok(value) = env::var("PYTHON")
+            && !value.trim().is_empty()
+        {
+            out.push(value);
         }
         out.push("python3".to_string());
         out.push("python".to_string());
@@ -643,15 +969,30 @@ if __name__ == '__main__':
                 .iter()
                 .position(|img| img.element_id == selection.element_id)
             {
-                if idx != selection.index {
+                if selection.kind != ImageSelectionKind::Attached || idx != selection.index {
                     self.selected_attachment = Some(AttachmentSelection {
+                        kind: ImageSelectionKind::Attached,
                         index: idx,
                         element_id: selection.element_id,
                     });
                 }
-            } else {
-                self.clear_selected_attachment();
+                return;
             }
+            if let Some(idx) = self
+                .detected_images
+                .iter()
+                .position(|img| img.element_id == selection.element_id)
+            {
+                if selection.kind != ImageSelectionKind::Detected || idx != selection.index {
+                    self.selected_attachment = Some(AttachmentSelection {
+                        kind: ImageSelectionKind::Detected,
+                        index: idx,
+                        element_id: selection.element_id,
+                    });
+                }
+                return;
+            }
+            self.clear_selected_attachment();
         }
     }
 
@@ -708,7 +1049,7 @@ if __name__ == '__main__':
         }
         let (label, color) = match self.interrupt_ui.intent {
             ComposerInterruptIntent::Add => ("[Add] ", Color::Yellow),
-            ComposerInterruptIntent::Interrupt => ("[interrupt] ", Color::Rgb(255, 140, 0)),
+            ComposerInterruptIntent::Interrupt => ("[interrupt] ", Color::LightRed),
         };
         let style = Style::default().fg(color).add_modifier(Modifier::BOLD);
         Some((label.to_string(), style))
@@ -757,6 +1098,7 @@ if __name__ == '__main__':
         self.textarea.insert_str(text);
         self.sync_command_popup();
         self.sync_file_search_popup();
+        self.refresh_detected_images();
     }
 
     /// Handle a key event coming from the main UI.
@@ -944,6 +1286,7 @@ if __name__ == '__main__':
         let text_after = self.textarea.text();
         self.pending_pastes
             .retain(|(placeholder, _)| text_after.contains(placeholder));
+        self.refresh_detected_images();
         (InputResult::None, true)
     }
 
@@ -1418,10 +1761,9 @@ if __name__ == '__main__':
 
         if matches!(input.kind, KeyEventKind::Press | KeyEventKind::Repeat)
             && !matches!(input.code, KeyCode::Tab | KeyCode::Right)
+            && self.selected_attachment.is_some()
         {
-            if self.selected_attachment.is_some() {
-                self.clear_selected_attachment();
-            }
+            self.clear_selected_attachment();
         }
 
         if let KeyEvent {
@@ -1430,15 +1772,13 @@ if __name__ == '__main__':
             kind,
             ..
         } = input
+            && self.interrupt_ui.enabled
+            && self.is_task_running
+            && modifiers.is_empty()
+            && matches!(kind, KeyEventKind::Press)
+            && self.toggle_interrupt_intent()
         {
-            if self.interrupt_ui.enabled
-                && self.is_task_running
-                && modifiers.is_empty()
-                && matches!(kind, KeyEventKind::Press)
-                && self.toggle_interrupt_intent()
-            {
-                return (InputResult::None, true);
-            }
+            return (InputResult::None, true);
         }
 
         if !matches!(input.code, KeyCode::Esc) {
@@ -1573,6 +1913,8 @@ if __name__ == '__main__':
             self.attached_images = kept;
             self.reconcile_selected_attachment();
         }
+
+        self.refresh_detected_images();
 
         (InputResult::None, true)
     }
@@ -2030,7 +2372,7 @@ mod tests {
     use crate::bottom_pane::AppEventSender;
     use crate::bottom_pane::ChatComposer;
     use crate::bottom_pane::InputResult;
-    use crate::bottom_pane::chat_composer::AttachedImage;
+
     use crate::bottom_pane::chat_composer::LARGE_PASTE_CHAR_THRESHOLD;
     use crate::bottom_pane::prompt_args::extract_positional_args_for_prompt_line;
     use crate::bottom_pane::textarea::TextArea;

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -668,6 +668,25 @@ impl TextArea {
         id
     }
 
+    pub fn create_element_for_range(&mut self, range: Range<usize>) -> Option<u64> {
+        if range.start >= range.end || range.end > self.text.len() {
+            return None;
+        }
+        if self.range_overlaps_element(&range) {
+            return None;
+        }
+        let id = self.next_element_id;
+        self.next_element_id = self.next_element_id.saturating_add(1);
+        self.add_element(TextElement {
+            id,
+            range,
+            style: default_element_style(),
+            display_override: None,
+            suffix: None,
+        });
+        Some(id)
+    }
+
     fn add_element(&mut self, element: TextElement) {
         self.elements.push(element);
         self.elements.sort_by_key(|e| e.range.start);
@@ -679,6 +698,20 @@ impl TextArea {
 
     pub fn element_exists(&self, id: u64) -> bool {
         self.find_element_index_by_id(id).is_some()
+    }
+
+    pub fn remove_element(&mut self, id: u64) -> bool {
+        if let Some(idx) = self.find_element_index_by_id(id) {
+            self.elements.remove(idx);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn element_range(&self, id: u64) -> Option<Range<usize>> {
+        self.find_element_index_by_id(id)
+            .map(|idx| self.elements[idx].range.clone())
     }
 
     pub fn set_element_style(&mut self, id: u64, style: Style) -> bool {
@@ -697,10 +730,10 @@ impl TextArea {
         suffix: Option<String>,
     ) -> bool {
         if let Some(idx) = self.find_element_index_by_id(id) {
-            if let Some(ref text) = display {
-                if text.len() != self.elements[idx].range.len() {
-                    return false;
-                }
+            if let Some(ref text) = display
+                && text.len() != self.elements[idx].range.len()
+            {
+                return false;
             }
             self.elements[idx].display_override = display;
             self.elements[idx].suffix = suffix;
@@ -796,6 +829,12 @@ impl TextArea {
                 e.range.end = new_end;
             }
         }
+    }
+
+    pub fn range_overlaps_element(&self, range: &Range<usize>) -> bool {
+        self.elements
+            .iter()
+            .any(|e| e.range.start < range.end && range.start < e.range.end)
     }
 
     fn update_elements_after_replace(&mut self, start: usize, end: usize, inserted_len: usize) {
@@ -1008,21 +1047,21 @@ impl TextArea {
                     }
                     let rel_start = overlap_start.saturating_sub(elem.range.start);
                     let rel_end = overlap_end.saturating_sub(elem.range.start);
-                    if let Some(slice) = display.get(rel_start..rel_end) {
-                        if !slice.is_empty() {
-                            buf.set_string(area.x + x_off, y, slice, elem.style);
-                        }
+                    if let Some(slice) = display.get(rel_start..rel_end)
+                        && !slice.is_empty()
+                    {
+                        buf.set_string(area.x + x_off, y, slice, elem.style);
                     }
                 } else {
                     buf.set_string(area.x + x_off, y, original_slice, elem.style);
                 }
 
-                if let Some(suffix) = &elem.suffix {
-                    if elem.range.end <= line_range.end {
-                        let prefix = &self.text[line_range.start..elem.range.end];
-                        let suffix_x = prefix.width() as u16;
-                        buf.set_string(area.x + suffix_x, y, suffix, elem.style);
-                    }
+                if let Some(suffix) = &elem.suffix
+                    && elem.range.end <= line_range.end
+                {
+                    let prefix = &self.text[line_range.start..elem.range.end];
+                    let suffix_x = prefix.width() as u16;
+                    buf.set_string(area.x + suffix_x, y, suffix, elem.style);
                 }
             }
         }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -24,6 +24,7 @@ use codex_core::protocol::ExecCommandEndEvent;
 use codex_core::protocol::ExitedReviewModeEvent;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::InputMessageKind;
+use codex_core::protocol::InterventionMode;
 use codex_core::protocol::ListCustomPromptsResponseEvent;
 use codex_core::protocol::McpListToolsResponseEvent;
 use codex_core::protocol::McpToolCallBeginEvent;
@@ -393,6 +394,7 @@ impl ChatWidget {
     fn on_task_started(&mut self) {
         self.bottom_pane.clear_ctrl_c_quit_hint();
         self.bottom_pane.set_task_running(true);
+        self.apply_interrupt_mode_to_composer();
         self.full_reasoning_buffer.clear();
         self.reasoning_buffer.clear();
         self.request_redraw();
@@ -403,6 +405,7 @@ impl ChatWidget {
         self.flush_answer_stream_with_separator();
         // Mark task stopped and request redraw now that all content is in history.
         self.bottom_pane.set_task_running(false);
+        self.apply_interrupt_mode_to_composer();
         self.running_commands.clear();
         self.request_redraw();
 
@@ -906,7 +909,7 @@ impl ChatWidget {
         let placeholder = EXAMPLE_PROMPTS[rng.random_range(0..EXAMPLE_PROMPTS.len())].to_string();
         let codex_op_tx = spawn_agent(config.clone(), app_event_tx.clone(), conversation_manager);
 
-        Self {
+        let mut chat = Self {
             app_event_tx: app_event_tx.clone(),
             frame_requester: frame_requester.clone(),
             codex_op_tx,
@@ -945,8 +948,10 @@ impl ChatWidget {
             ghost_snapshots_disabled: true,
             needs_final_message_separator: false,
             last_rendered_width: std::cell::Cell::new(None),
-            interrupt_mode_enabled: false,
-        }
+            interrupt_mode_enabled: true,
+        };
+        chat.apply_interrupt_mode_to_composer();
+        chat
     }
 
     /// Create a ChatWidget attached to an existing conversation (e.g., a fork).
@@ -970,7 +975,7 @@ impl ChatWidget {
         let codex_op_tx =
             spawn_agent_from_existing(conversation, session_configured, app_event_tx.clone());
 
-        Self {
+        let mut chat = Self {
             app_event_tx: app_event_tx.clone(),
             frame_requester: frame_requester.clone(),
             codex_op_tx,
@@ -1009,8 +1014,10 @@ impl ChatWidget {
             ghost_snapshots_disabled: true,
             needs_final_message_separator: false,
             last_rendered_width: std::cell::Cell::new(None),
-            interrupt_mode_enabled: false,
-        }
+            interrupt_mode_enabled: true,
+        };
+        chat.apply_interrupt_mode_to_composer();
+        chat
     }
 
     pub fn desired_height(&self, width: u16) -> u16 {
@@ -1143,6 +1150,9 @@ impl ChatWidget {
             SlashCommand::Model => {
                 self.open_model_popup();
             }
+            SlashCommand::Interrupt => {
+                self.open_interrupt_popup();
+            }
             SlashCommand::Approvals => {
                 self.open_approvals_popup();
             }
@@ -1267,44 +1277,83 @@ impl ChatWidget {
         self.app_event_tx.send(AppEvent::InsertHistoryCell(cell));
     }
 
+    fn message_to_items(user_message: &UserMessage) -> Vec<InputItem> {
+        let mut items: Vec<InputItem> = Vec::new();
+        if !user_message.text.is_empty() {
+            items.push(InputItem::Text {
+                text: user_message.text.clone(),
+            });
+        }
+        for path in &user_message.image_paths {
+            items.push(InputItem::LocalImage { path: path.clone() });
+        }
+        items
+    }
+
     fn submit_user_message(&mut self, user_message: UserMessage) {
-        let UserMessage { text, image_paths } = user_message;
-        if text.is_empty() && image_paths.is_empty() {
+        if user_message.text.is_empty() && user_message.image_paths.is_empty() {
             return;
         }
 
         self.capture_ghost_snapshot();
 
-        let mut items: Vec<InputItem> = Vec::new();
-
-        if !text.is_empty() {
-            items.push(InputItem::Text { text: text.clone() });
-        }
-
-        for path in image_paths {
-            items.push(InputItem::LocalImage { path });
-        }
+        let items = Self::message_to_items(&user_message);
 
         self.codex_op_tx
-            .send(Op::UserInput { items })
+            .send(Op::UserInput {
+                items,
+                intervention: None,
+            })
             .unwrap_or_else(|e| {
                 tracing::error!("failed to send message: {e}");
             });
 
         // Persist the text to cross-session message history.
-        if !text.is_empty() {
+        if !user_message.text.is_empty() {
             self.codex_op_tx
-                .send(Op::AddToHistory { text: text.clone() })
+                .send(Op::AddToHistory {
+                    text: user_message.text.clone(),
+                })
                 .unwrap_or_else(|e| {
                     tracing::error!("failed to send AddHistory op: {e}");
                 });
         }
 
         // Only show the text portion in conversation history.
-        if !text.is_empty() {
-            self.add_to_history(history_cell::new_user_prompt(text));
+        if !user_message.text.is_empty() {
+            self.add_to_history(history_cell::new_user_prompt(user_message.text));
         }
         self.needs_final_message_separator = false;
+    }
+
+    fn submit_interrupt_message(&mut self, user_message: UserMessage, mode: InterventionMode) {
+        if user_message.text.is_empty() && user_message.image_paths.is_empty() {
+            return;
+        }
+
+        self.capture_ghost_snapshot();
+
+        let items = Self::message_to_items(&user_message);
+
+        self.codex_op_tx
+            .send(Op::UserInput {
+                items,
+                intervention: Some(mode),
+            })
+            .unwrap_or_else(|e| {
+                tracing::error!("failed to send interrupt message: {e}");
+            });
+
+        if !user_message.text.is_empty() {
+            self.codex_op_tx
+                .send(Op::AddToHistory {
+                    text: user_message.text.clone(),
+                })
+                .unwrap_or_else(|e| {
+                    tracing::error!("failed to send AddHistory op: {e}");
+                });
+            self.add_to_history(history_cell::new_user_prompt(user_message.text));
+        }
     }
 
     fn capture_ghost_snapshot(&mut self) {
@@ -1549,13 +1598,25 @@ impl ChatWidget {
     }
 
     fn toggle_interrupt_mode(&mut self) {
-        self.interrupt_mode_enabled = !self.interrupt_mode_enabled;
-        self.bottom_pane
-            .set_interrupt_mode(self.interrupt_mode_enabled);
-        if !self.interrupt_mode_enabled {
+        let enabled = !self.interrupt_mode_enabled;
+        self.set_interrupt_mode_enabled(enabled);
+    }
+
+    fn apply_interrupt_mode_to_composer(&mut self) {
+        let active = self.interrupt_mode_enabled && self.bottom_pane.is_task_running();
+        self.bottom_pane.set_interrupt_mode(active);
+        if !active {
             self.bottom_pane
                 .set_interrupt_intent(ComposerInterruptIntent::Add);
         }
+    }
+
+    pub(crate) fn set_interrupt_mode_enabled(&mut self, enabled: bool) {
+        if self.interrupt_mode_enabled == enabled {
+            return;
+        }
+        self.interrupt_mode_enabled = enabled;
+        self.apply_interrupt_mode_to_composer();
         self.request_redraw();
     }
 
@@ -1566,13 +1627,10 @@ impl ChatWidget {
 
         match classification {
             InterruptSubmission::Add(message) => {
-                self.queued_user_messages.push_back(message);
-                self.refresh_queued_user_messages();
+                self.submit_interrupt_message(message, InterventionMode::Add);
             }
             InterruptSubmission::Interrupt(message) => {
-                self.submit_op(Op::Interrupt);
-                self.queued_user_messages.push_front(message);
-                self.refresh_queued_user_messages();
+                self.submit_interrupt_message(message, InterventionMode::Interrupt);
             }
         }
 
@@ -1625,24 +1683,9 @@ impl ChatWidget {
             base_intent
         };
 
-        const ADD_PREFIX: &str = "before going further, know that the user also want to add that..";
-        const INTERRUPT_PREFIX: &str = "Wait , it seems the user have something more to say  :";
-
         match intent {
-            ComposerInterruptIntent::Add => {
-                if user_message.text.is_empty() {
-                    user_message.text = ADD_PREFIX.to_string();
-                } else {
-                    user_message.text = format!("{ADD_PREFIX} {}", user_message.text);
-                }
-                Some(InterruptSubmission::Add(user_message))
-            }
+            ComposerInterruptIntent::Add => Some(InterruptSubmission::Add(user_message)),
             ComposerInterruptIntent::Interrupt => {
-                if user_message.text.is_empty() {
-                    user_message.text = INTERRUPT_PREFIX.to_string();
-                } else {
-                    user_message.text = format!("{INTERRUPT_PREFIX} {}", user_message.text);
-                }
                 Some(InterruptSubmission::Interrupt(user_message))
             }
         }
@@ -1765,6 +1808,46 @@ impl ChatWidget {
             title: Some("Select Model and Effort".to_string()),
             subtitle: Some("Switch the model for this and future Codex CLI sessions".to_string()),
             footer_hint: Some("Press enter to select reasoning effort, or esc to dismiss.".into()),
+            items,
+            ..Default::default()
+        });
+    }
+
+    pub(crate) fn open_interrupt_popup(&mut self) {
+        let mut items: Vec<SelectionItem> = Vec::new();
+        let options = [
+            (
+                true,
+                "On",
+                "Inject addenda or interruptions immediately during active tasks.",
+            ),
+            (
+                false,
+                "Off",
+                "Queue follow-up messages until the task finishes running.",
+            ),
+        ];
+
+        for (enabled, label, description) in options {
+            let is_current = self.interrupt_mode_enabled == enabled;
+            let actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
+                tx.send(AppEvent::UpdateInterruptMode(enabled));
+            })];
+
+            items.push(SelectionItem {
+                name: label.to_string(),
+                description: Some(description.to_string()),
+                is_current,
+                actions,
+                dismiss_on_select: true,
+                ..Default::default()
+            });
+        }
+
+        self.bottom_pane.show_selection_view(SelectionViewParams {
+            title: Some("Interrupt Mode".to_string()),
+            subtitle: Some("Choose how Codex handles new input while it is working.".to_string()),
+            footer_hint: Some(standard_popup_hint_line()),
             items,
             ..Default::default()
         });

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -13,6 +13,7 @@ pub enum SlashCommand {
     // DO NOT ALPHA-SORT! Enum order is presentation order in the popup, so
     // more frequently used commands should be listed first.
     Model,
+    Interrupt,
     Approvals,
     Review,
     New,
@@ -43,6 +44,7 @@ impl SlashCommand {
             SlashCommand::Mention => "mention a file",
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::Model => "choose what model and reasoning effort to use",
+            SlashCommand::Interrupt => "enable or disable interrupt mode",
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
@@ -72,7 +74,8 @@ impl SlashCommand {
             | SlashCommand::Mention
             | SlashCommand::Status
             | SlashCommand::Mcp
-            | SlashCommand::Quit => true,
+            | SlashCommand::Quit
+            | SlashCommand::Interrupt => true,
 
             #[cfg(debug_assertions)]
             SlashCommand::TestApproval => true,


### PR DESCRIPTION
## Summary
- send chat composer messages with intervention metadata, keep the interrupt affordance active while tasks stream, and surface a /interrupt popup to toggle the behavior
- store pending user input together with its intervention mode, inject add/interrupt prompts after command output, and format the text the model sees when a user interrupts

## Testing
- RUSTUP_TOOLCHAIN=nightly just fmt
- RUSTUP_TOOLCHAIN=nightly just fix -p codex-tui
- cargo test -p codex-tui
- cargo test --all-features *(aborted after an extended build; too slow for the session)*

------
https://chatgpt.com/codex/tasks/task_e_68e891003fe08329a6f9e0d12c059496